### PR TITLE
Lite Painting Updates

### DIFF
--- a/include/microstrain_inertial_driver_common/microstrain_defs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_defs.h
@@ -31,12 +31,14 @@ constexpr auto NUM_GNSS = 2;
  */
 #if MICROSTRAIN_ROS_VERSION == 1
 #include "ros/ros.h"
+#include "tf2_ros/transform_broadcaster.h"
 
 #include "sensor_msgs/NavSatFix.h"
 #include "sensor_msgs/Imu.h"
 #include "sensor_msgs/TimeReference.h"
 #include "geometry_msgs/PoseWithCovarianceStamped.h"
 #include "geometry_msgs/Vector3.h"
+#include "geometry_msgs/TransformStamped.h"
 #include "sensor_msgs/MagneticField.h"
 #include "nav_msgs/Odometry.h"
 #include "std_msgs/Int8.h"
@@ -118,6 +120,7 @@ constexpr auto NUM_GNSS = 2;
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+#include "tf2_ros/transform_broadcaster.h"
 
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
@@ -125,6 +128,7 @@ constexpr auto NUM_GNSS = 2;
 #include "sensor_msgs/msg/time_reference.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/vector3.hpp"
+#include "geometry_msgs/msg/transform_stamped.h"
 #include "sensor_msgs/msg/magnetic_field.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "std_msgs/msg/int8.hpp"
@@ -230,6 +234,7 @@ using GNSSAidingStatusMsg = ::microstrain_inertial_msgs::GNSSAidingStatus;
 using GNSSDualAntennaStatusMsg = ::microstrain_inertial_msgs::GNSSDualAntennaStatus;
 using FilterHeadingStateMsg = ::microstrain_inertial_msgs::FilterHeadingState;
 using GPSCorrelationTimestampStampedMsg = ::microstrain_inertial_msgs::GPSCorrelationTimestampStamped;
+using TransformStampedMsg = ::geometry_msgs::TransformStamped;
 
 // ROS1 Publisher Types
 using OdometryPubType = RosPubType;
@@ -245,6 +250,9 @@ using GNSSAidingStatusPubType = RosPubType;
 using GNSSDualAntennaStatusPubType = RosPubType;
 using FilterHeadingStatePubType = RosPubType;
 using GPSCorrelationTimestampStampedPubType = RosPubType;
+
+// ROS1 Transform Broadcaster
+using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster>;
 
 // ROS1 Subscriber Message Types
 using BoolMsg = ::std_msgs::Bool;
@@ -454,6 +462,7 @@ using GNSSAidingStatusMsg = ::microstrain_inertial_msgs::msg::GNSSAidingStatus;
 using GNSSDualAntennaStatusMsg = ::microstrain_inertial_msgs::msg::GNSSDualAntennaStatus;
 using FilterHeadingStateMsg = ::microstrain_inertial_msgs::msg::FilterHeadingState;
 using GPSCorrelationTimestampStampedMsg = ::microstrain_inertial_msgs::msg::GPSCorrelationTimestampStamped;
+using TransformStampedMsg = ::geometry_msgs::msg::TransformStamped;
 
 // ROS2 Publisher Types
 using OdometryPubType = ::rclcpp_lifecycle::LifecyclePublisher<OdometryMsg>::SharedPtr;
@@ -470,6 +479,9 @@ using GNSSDualAntennaStatusPubType = ::rclcpp_lifecycle::LifecyclePublisher<GNSS
 using FilterHeadingStatePubType = ::rclcpp_lifecycle::LifecyclePublisher<FilterHeadingStateMsg>::SharedPtr;
 using GPSCorrelationTimestampStampedPubType =
     ::rclcpp_lifecycle::LifecyclePublisher<GPSCorrelationTimestampStampedMsg>::SharedPtr;
+
+// ROS2 Transform Broadcaster
+using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster>;
 
 // ROS2 Subscriber Message Types
 using BoolMsg = ::std_msgs::msg::Bool;

--- a/include/microstrain_inertial_driver_common/microstrain_publishers.h
+++ b/include/microstrain_inertial_driver_common/microstrain_publishers.h
@@ -73,6 +73,9 @@ public:
   // Device Status Publisher
   StatusPubType device_status_pub_;
 
+  // Transform Broadcaster
+  TransformBroadcasterType transform_broadcaster_;
+
   // IMU Messages
   ImuMsg imu_msg_;
   MagneticFieldMsg mag_msg_;
@@ -98,6 +101,9 @@ public:
 
   // Device Status Message
   StatusMsg device_status_msg_;
+
+  // Published transforms
+  TransformStampedMsg filter_transform_msg_;
 
 private:
   RosNodeType* node_;

--- a/include/microstrain_inertial_driver_common/microstrain_ros_funcs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_ros_funcs.h
@@ -78,6 +78,16 @@ void get_param(RosNodeType* node, const std::string& param_name, ConfigType& par
 }
 
 /**
+ * \brief Creates a transform broadcaster
+ * \param node The ROS node that the broadcaster will be associated with
+ * \return Initialized shared pointer containing a transdorm broadcaster
+ */
+inline TransformBroadcasterType create_transform_broadcaster(RosNodeType* node)
+{
+  return std::make_shared<tf2_ros::TransformBroadcaster>();
+}
+
+/**
  * \brief Creates a ROS publisher
  * \tparam MessageType  The type of message that this publisher will publish
  * \param node  The ROS node to create the publisher on
@@ -221,6 +231,16 @@ void get_param(RosNodeType* node, const std::string& param_name, ConfigType& par
   {
     param_val = node->declare_parameter<ConfigType>(param_name, default_val);
   }
+}
+
+/**
+ * \brief Creates a transform broadcaster
+ * \param node The ROS node that the broadcaster will be associated with
+ * \return Initialized shared pointer containing a transdorm broadcaster
+ */
+inline TransformBroadcasterType create_transform_broadcaster(RosNodeType* node)
+{
+  return std::make_shared<tf2_ros::TransformBroadcaster>(node);
 }
 
 /**

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -75,6 +75,7 @@ bool MicrostrainConfig::configure(RosNodeType* node)
   get_param<bool>(node, "publish_filter", publish_filter_, false);
   get_param<int32_t>(node, "filter_data_rate", filter_data_rate_, 10);
   get_param<std::string>(node, "filter_frame_id", filter_frame_id_, filter_frame_id_);
+  get_param<std::string>(node, "filter_child_frame_id", filter_child_frame_id_, filter_child_frame_id_);
   get_param<bool>(node, "publish_relative_position", publish_filter_relative_pos_, false);
   get_param<double>(node, "gps_leap_seconds", gps_leap_seconds_, 18.0);
   get_param<bool>(node, "filter_angular_zupt", angular_zupt_, false);

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -271,6 +271,11 @@ bool MicrostrainConfig::setupDevice(RosNodeType* node)
     if (!configureRTK(node))
       return false;
   }
+  else
+  {
+    // TODO(robbiefish): This only works for GQ7 right now
+    inertial_device_->enableRtk(false);
+  }
 
   // Filter setup
   if (publish_filter_ && supports_filter_)

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -65,6 +65,7 @@ bool MicrostrainConfig::configure(RosNodeType* node)
   // GNSS 1/2
   get_param<bool>(node, "publish_gnss1", publish_gnss_[GNSS1_ID], false);
   get_param<bool>(node, "publish_gnss2", publish_gnss_[GNSS2_ID], false);
+  get_param<bool>(node, "rtk_dongle_enable", publish_rtk_, false);
   get_param<int32_t>(node, "gnss1_data_rate", gnss_data_rate_[GNSS1_ID], 1);
   get_param<int32_t>(node, "gnss2_data_rate", gnss_data_rate_[GNSS2_ID], 1);
   get_param<std::vector<double>>(node, "gnss1_antenna_offset", gnss_antenna_offset_[GNSS1_ID], DEFAULT_VECTOR);
@@ -95,6 +96,9 @@ bool MicrostrainConfig::configure(RosNodeType* node)
   get_param<std::string>(node, "filter_angular_zupt_topic", angular_zupt_topic_, std::string("/moving_ang"));
   get_param<std::string>(node, "filter_external_gps_time_topic", external_gps_time_topic_,
                          std::string("/external_gps_time"));
+
+  // Enable dual antenna messages
+  publish_gnss_dual_antenna_status_ = filter_enable_gnss_heading_aiding_;
 
   // Raw data file save
   get_param<bool>(node, "raw_file_enable", raw_file_enable_, false);
@@ -230,11 +234,9 @@ bool MicrostrainConfig::setupDevice(RosNodeType* node)
   // Read the config used by this section
   bool save_settings;
   bool gpio_config;
-  bool rtk_dongle_enable;
   bool filter_reset_after_config;
   get_param<bool>(node, "save_settings", save_settings, true);
   get_param<bool>(node, "gpio_config", gpio_config, false);
-  get_param<bool>(node, "rtk_dongle_enable", rtk_dongle_enable, false);
   get_param<bool>(node, "filter_reset_after_config", filter_reset_after_config, true);
 
   // GPIO config
@@ -266,15 +268,10 @@ bool MicrostrainConfig::setupDevice(RosNodeType* node)
   }
 
   // RTK Dongle
-  if (rtk_dongle_enable && supports_rtk_)
+  if (supports_rtk_)
   {
     if (!configureRTK(node))
       return false;
-  }
-  else
-  {
-    // TODO(robbiefish): This only works for GQ7 right now
-    inertial_device_->enableRtk(false);
   }
 
   // Filter setup
@@ -572,37 +569,38 @@ bool MicrostrainConfig::configureGNSS(RosNodeType* node, uint8_t gnss_id)
 
 bool MicrostrainConfig::configureRTK(RosNodeType* node)
 {
-  mscl::SampleRate gnss3_rate = mscl::SampleRate::Hertz(1);
-
-  MICROSTRAIN_INFO(node_, "Setting RTK data to stream at 1 hz");
-
-  mscl::MipTypes::MipChannelFields gnssChannels{ mscl::MipTypes::ChannelField::CH_FIELD_GNSS_3_RTK_CORRECTIONS_STATUS };
-
-  mscl::MipChannels supportedChannels;
-  for (mscl::MipTypes::ChannelField channel :
-       inertial_device_->features().supportedChannelFields(mscl::MipTypes::DataClass::CLASS_GNSS3))
+  if (publish_rtk_)
   {
-    if (std::find(gnssChannels.begin(), gnssChannels.end(), channel) != gnssChannels.end())
+    mscl::SampleRate gnss3_rate = mscl::SampleRate::Hertz(1);
+
+    MICROSTRAIN_INFO(node_, "Setting RTK data to stream at 1 hz");
+
+    mscl::MipTypes::MipChannelFields gnssChannels{ mscl::MipTypes::ChannelField::CH_FIELD_GNSS_3_RTK_CORRECTIONS_STATUS };
+
+    mscl::MipChannels supportedChannels;
+    for (mscl::MipTypes::ChannelField channel :
+        inertial_device_->features().supportedChannelFields(mscl::MipTypes::DataClass::CLASS_GNSS3))
     {
-      supportedChannels.push_back(mscl::MipChannel(channel, gnss3_rate));
+      if (std::find(gnssChannels.begin(), gnssChannels.end(), channel) != gnssChannels.end())
+      {
+        supportedChannels.push_back(mscl::MipChannel(channel, gnss3_rate));
+      }
     }
+
+    inertial_device_->enableDataStream(mscl::MipTypes::DataClass::CLASS_GNSS3);
   }
 
-  // set the GNSS channel fields
-  inertial_device_->setActiveChannelFields(mscl::MipTypes::DataClass::CLASS_GNSS3, supportedChannels);
-
+  // Check if the device even supports the RTK command, and enable/disable accordingly
   if (inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_GNSS_RTK_CONFIG))
   {
-    MICROSTRAIN_INFO(node_, "Setting RTK dongle enable to 1");
-    inertial_device_->enableRtk(true);
-    publish_rtk_ = true;
+    MICROSTRAIN_INFO(node_, "Setting RTK dongle enable to %d", publish_rtk_);
+    inertial_device_->enableRtk(publish_rtk_);
   }
   else
   {
     MICROSTRAIN_INFO(node_, "Note: Device does not support the RTK dongle config command");
   }
 
-  inertial_device_->enableDataStream(mscl::MipTypes::DataClass::CLASS_GNSS3);
   return true;
 }
 
@@ -911,9 +909,6 @@ bool MicrostrainConfig::configureFilter(RosNodeType* node)
   {
     MICROSTRAIN_INFO(node_, "Note: The device does not support the next-gen filter initialization command.");
   }
-
-  // Enable dual antenna messages
-  publish_gnss_dual_antenna_status_ = filter_enable_gnss_heading_aiding_;
 
   // Enable the filter datastream
   inertial_device_->enableDataStream(mscl::MipTypes::DataClass::CLASS_ESTFILTER);

--- a/src/microstrain_publishers.cpp
+++ b/src/microstrain_publishers.cpp
@@ -29,6 +29,9 @@ bool MicrostrainPublishers::configure()
     device_status_pub_ = create_publisher<StatusMsg>(node_, "device/status", 100);
   }
 
+  // Create the transorm broadcaster
+  transform_broadcaster_ = create_transform_broadcaster(node_);
+
   // Publish IMU data, if enabled
   if (config_->publish_imu_)
   {


### PR DESCRIPTION
* Adds transform broadcaster that will publish transform between `filter_frame_id` and `filter_child_frame_id`
* Corrects some ENU conversions that were not being properly made
* Properly disables/enables RTK dongle based on launch config
* Publishes RTK data even when `device_setup` is set to false if the device was configured to send RTK data