### PR TITLE
Feature/rtcm sub

### DIFF
--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -120,7 +120,7 @@ public:
 
   // Device pointer used to interact with the device
   std::unique_ptr<mscl::InertialNode> inertial_device_;
-  mscl::Connection aux_connection_;
+  std::unique_ptr<mscl::Connection> aux_connection_;
 
   // Config read from the device
   bool supports_gnss1_;

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -155,6 +155,7 @@ public:
   std::string gnss_frame_id_[NUM_GNSS];
   std::string filter_frame_id_;
   std::string filter_child_frame_id_;
+  std::string nmea_frame_id_;
 
   // Topic strings
   std::string velocity_zupt_topic_;

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -120,6 +120,7 @@ public:
 
   // Device pointer used to interact with the device
   std::unique_ptr<mscl::InertialNode> inertial_device_;
+  mscl::Connection aux_connection_;
 
   // Config read from the device
   bool supports_gnss1_;
@@ -169,6 +170,11 @@ public:
   bool publish_filter_;
   bool publish_filter_relative_pos_;
   bool publish_rtk_;
+  bool publish_nmea_;
+
+  // RTCM subscriber
+  bool subscribe_rtcm_;
+  std::string rtcm_topic_;
 
   // ZUPT, angular ZUPT topic listener variables
   bool angular_zupt_;

--- a/include/microstrain_inertial_driver_common/microstrain_defs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_defs.h
@@ -501,7 +501,7 @@ using RTCMMsg = ::mavros_msgs::msg::RTCM;
 // ROS2 Subscriber Types
 using BoolSubType = ::rclcpp::Subscription<BoolMsg>::SharedPtr;
 using TimeReferenceSubType = ::rclcpp::Subscription<TimeReferenceMsg>::SharedPtr;
-using RTCMSubType = rclcpp::Subscription<RTCMMsg>::ShardPtr;
+using RTCMSubType = rclcpp::Subscription<RTCMMsg>::SharedPtr;
 
 // ROS2 Service Message Types
 using TriggerServiceMsg = std_srvs::srv::Trigger;

--- a/include/microstrain_inertial_driver_common/microstrain_defs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_defs.h
@@ -47,6 +47,8 @@ constexpr auto NUM_GNSS = 2;
 #include "std_msgs/Bool.h"
 #include "std_msgs/String.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "mavros_msgs/RTCM.h"
+#include "nmea_msgs/Sentence.h"
 
 #include "microstrain_inertial_msgs/Status.h"
 #include "microstrain_inertial_msgs/RTKStatus.h"
@@ -139,6 +141,8 @@ constexpr auto NUM_GNSS = 2;
 #include "std_msgs/msg/bool.hpp"
 #include "std_msgs/msg/string.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "mavros_msgs/msg/rtcm.hpp"
+#include "nmea_msgs/msg/sentence.hpp"
 
 #include "microstrain_inertial_msgs/msg/status.hpp"
 #include "microstrain_inertial_msgs/msg/rtk_status.hpp"
@@ -226,6 +230,7 @@ using ImuMsg = ::sensor_msgs::Imu;
 using NavSatFixMsg = ::sensor_msgs::NavSatFix;
 using MagneticFieldMsg = ::sensor_msgs::MagneticField;
 using TimeReferenceMsg = ::sensor_msgs::TimeReference;
+using NMEASentenceMsg = ::nmea_msgs::Sentence;
 using StatusMsg = ::microstrain_inertial_msgs::Status;
 using RTKStatusMsg = ::microstrain_inertial_msgs::RTKStatus;
 using FilterStatusMsg = ::microstrain_inertial_msgs::FilterStatus;
@@ -242,6 +247,7 @@ using ImuPubType = RosPubType;
 using NavSatFixPubType = RosPubType;
 using MagneticFieldPubType = RosPubType;
 using TimeReferencePubType = RosPubType;
+using NMEASentencePubType = RosPubType;
 using StatusPubType = RosPubType;
 using RTKStatusPubType = RosPubType;
 using FilterStatusPubType = RosPubType;
@@ -257,10 +263,12 @@ using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster
 // ROS1 Subscriber Message Types
 using BoolMsg = ::std_msgs::Bool;
 using TimeReferenceMsg = ::sensor_msgs::TimeReference;
+using RTCMMsg = ::mavros_msgs::RTCM;
 
 // ROS1 Subscriber Types
 using BoolSubType = RosSubType;
 using TimeReferenceSubType = RosSubType;
+using RTCMSubType = RosSubType;
 
 // ROS1 Service Message Types
 using TriggerServiceMsg = std_srvs::Trigger;
@@ -454,6 +462,7 @@ using ImuMsg = ::sensor_msgs::msg::Imu;
 using NavSatFixMsg = ::sensor_msgs::msg::NavSatFix;
 using MagneticFieldMsg = ::sensor_msgs::msg::MagneticField;
 using TimeReferenceMsg = ::sensor_msgs::msg::TimeReference;
+using NMEASentenceMsg = ::nmea_msgs::msg::Sentence;
 using StatusMsg = ::microstrain_inertial_msgs::msg::Status;
 using RTKStatusMsg = ::microstrain_inertial_msgs::msg::RTKStatus;
 using FilterStatusMsg = ::microstrain_inertial_msgs::msg::FilterStatus;
@@ -470,6 +479,7 @@ using ImuPubType = ::rclcpp_lifecycle::LifecyclePublisher<ImuMsg>::SharedPtr;
 using NavSatFixPubType = ::rclcpp_lifecycle::LifecyclePublisher<NavSatFixMsg>::SharedPtr;
 using MagneticFieldPubType = ::rclcpp_lifecycle::LifecyclePublisher<MagneticFieldMsg>::SharedPtr;
 using TimeReferencePubType = ::rclcpp_lifecycle::LifecyclePublisher<TimeReferenceMsg>::SharedPtr;
+using NMEASentencePubType = ::rclcpp_lifecycle::LifecyclePublisher<NMEASentenceMsg>::SharedPtr;
 using StatusPubType = ::rclcpp_lifecycle::LifecyclePublisher<StatusMsg>::SharedPtr;
 using RTKStatusPubType = ::rclcpp_lifecycle::LifecyclePublisher<RTKStatusMsg>::SharedPtr;
 using FilterStatusPubType = ::rclcpp_lifecycle::LifecyclePublisher<FilterStatusMsg>::SharedPtr;
@@ -486,10 +496,12 @@ using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster
 // ROS2 Subscriber Message Types
 using BoolMsg = ::std_msgs::msg::Bool;
 using TimeReferenceMsg = ::sensor_msgs::msg::TimeReference;
+using RTCMMsg = ::mavros_msgs::msg::RTCM;
 
 // ROS2 Subscriber Types
 using BoolSubType = ::rclcpp::Subscription<BoolMsg>::SharedPtr;
 using TimeReferenceSubType = ::rclcpp::Subscription<TimeReferenceMsg>::SharedPtr;
+using RTCMSubType = rclcpp::Subscription<RTCMMsg>::ShardPtr;
 
 // ROS2 Service Message Types
 using TriggerServiceMsg = std_srvs::srv::Trigger;

--- a/include/microstrain_inertial_driver_common/microstrain_node_base.h
+++ b/include/microstrain_inertial_driver_common/microstrain_node_base.h
@@ -33,9 +33,14 @@ class MicrostrainNodeBase
 {
 public:
   /**
-   * \brief Reads messages from the device, parses them, and publishes them. Meant to be executed in a loop
+   * \brief Reads messages from the main port of the device, parses them, and publishes them. Meant to be executed in a loop
    */
-  void parseAndPublish();
+  void parseAndPublishMain();
+
+  /**
+   * \brief Reads messages from the aux port of the device, parses them, and publishes them. Meant to be executed in a loop
+   */
+  void parseAndPublishAux();
 
 protected:
   /**
@@ -82,7 +87,8 @@ protected:
 
   double timer_update_rate_hz_;
 
-  RosTimerType parsing_timer_;
+  RosTimerType main_parsing_timer_;
+  RosTimerType aux_parsing_timer_;
   RosTimerType device_status_timer_;
 };  // MicrostrainNodeBase class
 

--- a/include/microstrain_inertial_driver_common/microstrain_parser.h
+++ b/include/microstrain_inertial_driver_common/microstrain_parser.h
@@ -44,6 +44,12 @@ public:
    */
   void parseMIPPacket(const mscl::MipDataPacket& packet);
 
+  /**
+   * \brief Parsing function that will parse the strings returned by the aux port of a GQ7
+   * \param aux_string The string read from the aux port 
+   */
+  void parseAuxString(const std::string& aux_string);
+
 private:
   /**
    * \brief Parses IMU packets if the MIP packet was an IMU packet and saves the data into a ROS message that will be published when it is filled out

--- a/include/microstrain_inertial_driver_common/microstrain_publishers.h
+++ b/include/microstrain_inertial_driver_common/microstrain_publishers.h
@@ -73,6 +73,9 @@ public:
   // Device Status Publisher
   StatusPubType device_status_pub_;
 
+  // NMEA Sentence Publisher
+  NMEASentencePubType nmea_sentence_pub_;
+
   // Transform Broadcaster
   TransformBroadcasterType transform_broadcaster_;
 
@@ -101,6 +104,9 @@ public:
 
   // Device Status Message
   StatusMsg device_status_msg_;
+
+  // NMEA Sentence Message
+  NMEASentenceMsg nmea_sentence_msg_;
 
   // Published transforms
   TransformStampedMsg filter_transform_msg_;

--- a/include/microstrain_inertial_driver_common/microstrain_subscribers.h
+++ b/include/microstrain_inertial_driver_common/microstrain_subscribers.h
@@ -68,7 +68,13 @@ public:
    * \brief Accepts external GPS time to set time on the device
    * \param time  Message containing external GPS time
    */
-  void external_gps_time_callback(const TimeReferenceMsg& time);
+  void externalGpsTimeCallback(const TimeReferenceMsg& time);
+
+  /**
+   * \brief Accepts RTCM corrections from a ROS topic
+   * \param rtcm Message containing 
+   */
+  void rtcmCallback(const RTCMMsg& rtcm);
 
   // ZUPT subscribers
   BoolSubType filter_vel_state_sub_;
@@ -76,6 +82,9 @@ public:
 
   // External GNSS subscriber
   TimeReferenceSubType external_gps_time_sub_;
+
+  // RTCM subscriber
+  RTCMSubType rtcm_sub_;
 
 private:
   // Node Information

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -34,6 +34,7 @@ bool MicrostrainConfig::configure(RosNodeType* node)
   gnss_frame_id_[GNSS2_ID] = "gnss2_antenna_wgs84_ned";
   filter_frame_id_ = "sensor_wgs84_ned";
   filter_child_frame_id_ = "sensor";
+  nmea_frame_id_ = "nmea";
   t_ned2enu_ = tf2::Matrix3x3(0, 1, 0, 1, 0, 0, 0, 0, -1);
   t_vehiclebody2sensorbody_ = tf2::Matrix3x3(1, 0, 0, 0, -1, 0, 0, 0, -1);
 
@@ -77,6 +78,7 @@ bool MicrostrainConfig::configure(RosNodeType* node)
   get_param<bool>(node, "subscribe_rtcm", subscribe_rtcm_, false);
   get_param<std::string>(node, "rtcm_topic", rtcm_topic_, std::string("/rtcm"));
   get_param<bool>(node, "publish_nmea", publish_nmea_, false);
+  get_param<std::string>(node, "nmea_frame_id", nmea_frame_id_, nmea_frame_id_);
 
   // FILTER
   get_param<bool>(node, "publish_filter", publish_filter_, false);

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -227,7 +227,8 @@ bool MicrostrainConfig::connectDevice(RosNodeType* node)
     if (supports_rtk_ && (subscribe_rtcm_ || publish_nmea_))
     {
       MICROSTRAIN_INFO(node_, "Attempting to open aux serial port <%s> at <%d>", aux_port.c_str(), baudrate);
-      aux_connection_ = mscl::Connection::Serial(realpath(port.c_str(), 0), (uint32_t)baudrate);
+      aux_connection_ = std::unique_ptr<mscl::Connection>(new mscl::Connection(mscl::Connection::Serial(realpath(aux_port.c_str(), 0), (uint32_t)baudrate)));
+      aux_connection_->rawByteMode(true);
     }
 
   }

--- a/src/microstrain_node_base.cpp
+++ b/src/microstrain_node_base.cpp
@@ -28,6 +28,8 @@ void MicrostrainNodeBase::parseAndPublish()
     parser_.parseMIPPacket(packet);
   }
 
+  // TODO(robbiefish): If we can publish NMEA messages, do that here
+
   // Save raw data, if enabled
   if (config_.raw_file_enable_)
   {

--- a/src/microstrain_node_base.cpp
+++ b/src/microstrain_node_base.cpp
@@ -29,6 +29,11 @@ void MicrostrainNodeBase::parseAndPublish()
   }
 
   // TODO(robbiefish): If we can publish NMEA messages, do that here
+  const auto& nmea_sentence = config_.aux_connection_->getRawBytesStr();
+  if (nmea_sentence.size() > 0)
+  {
+    std::cout << nmea_sentence << std::endl;
+  }
 
   // Save raw data, if enabled
   if (config_.raw_file_enable_)

--- a/src/microstrain_node_base.cpp
+++ b/src/microstrain_node_base.cpp
@@ -19,20 +19,12 @@
 namespace microstrain
 {
 
-void MicrostrainNodeBase::parseAndPublish()
+void MicrostrainNodeBase::parseAndPublishMain()
 {
   mscl::MipDataPackets packets = config_.inertial_device_->getDataPackets(1000);
-
   for (mscl::MipDataPacket packet : packets)
   {
     parser_.parseMIPPacket(packet);
-  }
-
-  // TODO(robbiefish): If we can publish NMEA messages, do that here
-  const auto& nmea_sentence = config_.aux_connection_->getRawBytesStr();
-  if (nmea_sentence.size() > 0)
-  {
-    std::cout << nmea_sentence << std::endl;
   }
 
   // Save raw data, if enabled
@@ -46,6 +38,11 @@ void MicrostrainNodeBase::parseAndPublish()
       config_.raw_file_.write(reinterpret_cast<const char*>(raw_packet_bytes.data()), raw_packet_bytes.size());
     }
   }
+}
+
+void MicrostrainNodeBase::parseAndPublishAux()
+{
+  parser_.parseAuxString(config_.aux_connection_->getRawBytesStr());
 }
 
 bool MicrostrainNodeBase::initialize(RosNodeType* init_node)
@@ -120,7 +117,8 @@ bool MicrostrainNodeBase::activate()
 bool MicrostrainNodeBase::deactivate()
 {
   // Stop the timers.
-  stop_timer(parsing_timer_);
+  stop_timer(main_parsing_timer_);
+  stop_timer(aux_parsing_timer_);
   stop_timer(device_status_timer_);
 
   // Set the device to idle
@@ -134,7 +132,6 @@ bool MicrostrainNodeBase::deactivate()
     {
       // Not much we can actually do at this point, so just log the error
       MICROSTRAIN_ERROR(node_, "Unable to set node to idle: %s", e.what());
-      return false;
     }
   }
 
@@ -144,7 +141,8 @@ bool MicrostrainNodeBase::deactivate()
 bool MicrostrainNodeBase::shutdown()
 {
   // Reset the timers
-  parsing_timer_.reset();
+  main_parsing_timer_.reset();
+  aux_parsing_timer_.reset();
   device_status_timer_.reset();
 
   // Disconnect the device
@@ -158,7 +156,20 @@ bool MicrostrainNodeBase::shutdown()
     {
       // Not much we can actually do at this point, so just log the error
       MICROSTRAIN_ERROR(node_, "Unable to disconnect node: %s", e.what());
-      return false;
+    }
+  }
+
+  // Disconnect the aux device
+  if (config_.aux_connection_)
+  {
+    try
+    {
+      config_.aux_connection_->disconnect();
+    }
+    catch (const mscl::Error& e)
+    {
+      // Not much we can actually do at this point, so just log the error
+      MICROSTRAIN_ERROR(node_, "Unable to disconnect aux port: %s", e.what());
     }
   }
 

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -84,6 +84,14 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
       break;
     }
 
+    // If there is another $ between the first $ and the end string, the first $ might have been part of a MIP message, so start over at the second $
+    const size_t possible_mid_index = aux_string.find('$', nmea_start_index + 1);
+    if (possible_mid_index != std::string::npos && possible_mid_index < nmea_end_index)
+    {
+      search_index = possible_mid_index;
+      continue;
+    }
+
     // Get the NMEA substring, and update the index for the next iteration
     const std::string& nmea_sentence = aux_string.substr(nmea_start_index, nmea_end_index - nmea_start_index);
     search_index = nmea_end_index + 1;

--- a/src/microstrain_publishers.cpp
+++ b/src/microstrain_publishers.cpp
@@ -114,6 +114,13 @@ bool MicrostrainPublishers::configure()
       filter_relative_pos_pub_ = create_publisher<OdometryMsg>(node_, "nav/relative_pos/odom", 100);
     }
   }
+
+  // If the device supports RTK (has an aux port), and we were asked to, stream NMEA sentences
+  if (config_->supports_rtk_ && config_->publish_nmea_)
+  {
+    MICROSTRAIN_INFO(node_, "Publishing NMEA sentences from aux port");
+    nmea_sentence_pub_ = create_publisher<NMEASentenceMsg>(node_, "nmea/sentence", 100);
+  }
   return true;
 }
 

--- a/src/microstrain_subscribers.cpp
+++ b/src/microstrain_subscribers.cpp
@@ -188,7 +188,7 @@ void MicrostrainSubscribers::rtcmCallback(const RTCMMsg& rtcm)
 {
   try
   {
-    config_->aux_connection_.write(rtcm.data);
+    config_->aux_connection_->write(rtcm.data);
   }
   catch (mscl::Error& e)
   {

--- a/src/microstrain_subscribers.cpp
+++ b/src/microstrain_subscribers.cpp
@@ -52,8 +52,17 @@ bool MicrostrainSubscribers::activate()
   if (config_->filter_enable_external_gps_time_update_ &&
       config_->inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_GPS_TIME_UPDATE))
   {
+    MICROSTRAIN_INFO(node_, "Subscribed to %s for external GPS time", config_->external_gps_time_topic_.c_str());
     external_gps_time_sub_ = create_subscriber<>(node_, config_->external_gps_time_topic_.c_str(), 1000,
-                                                  &MicrostrainSubscribers::external_gps_time_callback, this);
+                                                  &MicrostrainSubscribers::externalGpsTimeCallback, this);
+  }
+
+  // Create a topic listener for external RTCM updates
+  if (config_->subscribe_rtcm_ && config_->supports_rtk_)
+  {
+    MICROSTRAIN_INFO(node_, "Subscribed to %s for RTCM corrections", config_->rtcm_topic_.c_str());
+    rtcm_sub_ = create_subscriber<>(node_, config_->rtcm_topic_.c_str(), 1000,
+                                    &MicrostrainSubscribers::rtcmCallback, this);
   }
   return true;
 }
@@ -148,7 +157,7 @@ void MicrostrainSubscribers::angZupt()
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 // External GPS Time Callback
 /////////////////////////////////////////////////////////////////////////////////////////////////////
-void MicrostrainSubscribers::external_gps_time_callback(const TimeReferenceMsg& time)
+void MicrostrainSubscribers::externalGpsTimeCallback(const TimeReferenceMsg& time)
 {
   if (config_->inertial_device_)
   {
@@ -169,6 +178,21 @@ void MicrostrainSubscribers::external_gps_time_callback(const TimeReferenceMsg& 
     {
       MICROSTRAIN_ERROR(node_, "Error: %s", e.what());
     }
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// RTCM Callback
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+void MicrostrainSubscribers::rtcmCallback(const RTCMMsg& rtcm)
+{
+  try
+  {
+    config_->aux_connection_.write(rtcm.data);
+  }
+  catch (mscl::Error& e)
+  {
+    MICROSTRAIN_ERROR(node_, "Error sending RTCM corrections: %s", e.what());
   }
 }
 


### PR DESCRIPTION
* Adds RTCM subscriber that will subscribe to RTCM corrections as [mavros_msgs/RTCM](http://docs.ros.org/en/api/mavros_msgs/html/msg/RTCM.html) messages and send them to the GQ7 through the aux port
* Adds NMEA publisher that will read NMEA sentences from the GQ7 aux port and publish them as [nmea_msgs/Sentence](http://docs.ros.org/en/api/nmea_msgs/html/msg/Sentence.html) messages to a topic
* Updates to use `FACTORY_STREAMING_MERGE` instead of manually casting the hex value when factory streaming is enabled