### PR TITLE
Feature/odom sub

### DIFF
--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -136,6 +136,9 @@ public:
   // Flag for using device timestamp instead of PC received time
   bool use_device_timestamp_;
 
+  // Whether to enable the hardware odometer through the GPIO pins
+  bool enable_hardware_odometer_;
+
   // FILTER
   double gps_leap_seconds_;
   bool filter_enable_gnss_heading_aiding_;
@@ -159,6 +162,7 @@ public:
   std::string velocity_zupt_topic_;
   std::string angular_zupt_topic_;
   std::string external_gps_time_topic_;
+  std::string external_speed_topic_;
 
   // Publish data flags
   bool publish_imu_;

--- a/include/microstrain_inertial_driver_common/microstrain_defs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_defs.h
@@ -57,6 +57,8 @@ constexpr auto NUM_GNSS = 2;
 #include "microstrain_inertial_msgs/GNSSAidingStatus.h"
 #include "microstrain_inertial_msgs/GNSSDualAntennaStatus.h"
 
+#include "microstrain_inertial_msgs/InputSpeedMeasurement.h"
+
 #include "std_srvs/Empty.h"
 #include "std_srvs/Trigger.h"
 
@@ -112,6 +114,7 @@ constexpr auto NUM_GNSS = 2;
 #include "microstrain_inertial_msgs/ExternalHeadingUpdate.h"
 #include "microstrain_inertial_msgs/SetRelativePositionReference.h"
 #include "microstrain_inertial_msgs/GetRelativePositionReference.h"
+#include "microstrain_inertial_msgs/SetFilterSpeedLeverArm.h"
 
 /**
  * ROS2 Includes
@@ -148,6 +151,8 @@ constexpr auto NUM_GNSS = 2;
 #include "microstrain_inertial_msgs/msg/gps_correlation_timestamp_stamped.hpp"
 #include "microstrain_inertial_msgs/msg/gnss_aiding_status.hpp"
 #include "microstrain_inertial_msgs/msg/gnss_dual_antenna_status.hpp"
+
+#include "microstrain_inertial_msgs/msg/input_speed_measurement.hpp"
 
 #include "microstrain_inertial_msgs/srv/set_accel_bias.hpp"
 #include "microstrain_inertial_msgs/srv/get_accel_bias.hpp"
@@ -201,6 +206,7 @@ constexpr auto NUM_GNSS = 2;
 #include "microstrain_inertial_msgs/srv/external_heading_update.hpp"
 #include "microstrain_inertial_msgs/srv/set_relative_position_reference.hpp"
 #include "microstrain_inertial_msgs/srv/get_relative_position_reference.hpp"
+#include "microstrain_inertial_msgs/srv/set_filter_speed_lever_arm.hpp"
 #else
 #error "Unsupported ROS version. -DMICROSTRAIN_ROS_VERSION must be set to 1 or 2"
 #endif
@@ -257,10 +263,12 @@ using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster
 // ROS1 Subscriber Message Types
 using BoolMsg = ::std_msgs::Bool;
 using TimeReferenceMsg = ::sensor_msgs::TimeReference;
+using InputSpeedMeasurementMsg = ::microstrain_inertial_msgs::InputSpeedMeasurement;
 
 // ROS1 Subscriber Types
 using BoolSubType = RosSubType;
 using TimeReferenceSubType = RosSubType;
+using InputSpeedMeasurementSubType = RosSubType;
 
 // ROS1 Service Message Types
 using TriggerServiceMsg = std_srvs::Trigger;
@@ -346,6 +354,8 @@ using GetRelativePositionReferenceServiceMsg = ::microstrain_inertial_msgs::GetR
 
 using DeviceSettingsServiceMsg = ::microstrain_inertial_msgs::DeviceSettings;
 
+using SetFilterSpeedLeverArmServiceMsg = ::microstrain_inertial_msgs::SetFilterSpeedLeverArm;
+
 // ROS1 Service Types
 using TriggerServiceType = RosServiceType;
 using EmptyServiceType = RosServiceType;
@@ -430,6 +440,8 @@ using GetRelativePositionReferenceServiceType = RosServiceType;
 
 using DeviceSettingsServiceType = RosServiceType;
 
+using SetFilterSpeedLeverArmServiceType = RosServiceType;
+
 // ROS1 Logging
 #define MICROSTRAIN_DEBUG(NODE, ...) ROS_DEBUG(__VA_ARGS__)
 #define MICROSTRAIN_INFO(NODE, ...) ROS_INFO(__VA_ARGS__)
@@ -486,10 +498,12 @@ using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster
 // ROS2 Subscriber Message Types
 using BoolMsg = ::std_msgs::msg::Bool;
 using TimeReferenceMsg = ::sensor_msgs::msg::TimeReference;
+using InputSpeedMeasurementMsg = ::microstrain_inertial_msg::msg::InputSpeedMeasurement;
 
 // ROS2 Subscriber Types
 using BoolSubType = ::rclcpp::Subscription<BoolMsg>::SharedPtr;
 using TimeReferenceSubType = ::rclcpp::Subscription<TimeReferenceMsg>::SharedPtr;
+using InputSpeedMeasurementSubType = ::rclcpp::Subscription<InputSpeedMeasurementMsg>::SharedPtr;
 
 // ROS2 Service Message Types
 using TriggerServiceMsg = std_srvs::srv::Trigger;
@@ -574,6 +588,8 @@ using SetRelativePositionReferenceServiceMsg = microstrain_inertial_msgs::srv::S
 using GetRelativePositionReferenceServiceMsg = microstrain_inertial_msgs::srv::GetRelativePositionReference;
 
 using DeviceSettingsServiceMsg = microstrain_inertial_msgs::srv::DeviceSettings;
+
+using SetFilterSpeedLeverArmServiceMsg = microstrain_inertial_msgs::srv::SetFilterSpeedLeverArm;
 
 // ROS2 Service Types
 using TriggerServiceType = ::rclcpp::Service<TriggerServiceMsg>::SharedPtr;
@@ -661,6 +677,8 @@ using SetRelativePositionReferenceServiceType = ::rclcpp::Service<SetRelativePos
 using GetRelativePositionReferenceServiceType = ::rclcpp::Service<GetRelativePositionReferenceServiceMsg>::SharedPtr;
 
 using DeviceSettingsServiceType = ::rclcpp::Service<DeviceSettingsServiceMsg>::SharedPtr;
+
+using SetFilterSpeedLeverArmServiceType = ::rclcpp::Service<SetFilterSpeedLeverArmServiceMsg>::SharedPtr;
 
 // ROS2 Logging
 #define MICROSTRAIN_DEBUG(NODE, ...) RCLCPP_DEBUG(NODE->get_logger(), __VA_ARGS__)

--- a/include/microstrain_inertial_driver_common/microstrain_defs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_defs.h
@@ -498,7 +498,7 @@ using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster
 // ROS2 Subscriber Message Types
 using BoolMsg = ::std_msgs::msg::Bool;
 using TimeReferenceMsg = ::sensor_msgs::msg::TimeReference;
-using InputSpeedMeasurementMsg = ::microstrain_inertial_msg::msg::InputSpeedMeasurement;
+using InputSpeedMeasurementMsg = ::microstrain_inertial_msgs::msg::InputSpeedMeasurement;
 
 // ROS2 Subscriber Types
 using BoolSubType = ::rclcpp::Subscription<BoolMsg>::SharedPtr;

--- a/include/microstrain_inertial_driver_common/microstrain_services.h
+++ b/include/microstrain_inertial_driver_common/microstrain_services.h
@@ -159,6 +159,9 @@ public:
 
   bool deviceSettings(DeviceSettingsServiceMsg::Request& req, DeviceSettingsServiceMsg::Response& res);
 
+  bool setFilterSpeedLeverArm(SetFilterSpeedLeverArmServiceMsg::Request& req,
+                                SetFilterSpeedLeverArmServiceMsg::Response& res);
+
 private:
   RosNodeType* node_;
   MicrostrainConfig* config_;
@@ -222,6 +225,7 @@ private:
   ExternalHeadingUpdateServiceType external_heading_service_;
   SetRelativePositionReferenceServiceType set_relative_position_reference_service_;
   GetRelativePositionReferenceServiceType get_relative_position_reference_service_;
+  SetFilterSpeedLeverArmServiceType set_filter_speed_lever_arm_service_;
 };  // struct MicrostrainServices
 
 }  // namespace microstrain

--- a/include/microstrain_inertial_driver_common/microstrain_subscribers.h
+++ b/include/microstrain_inertial_driver_common/microstrain_subscribers.h
@@ -70,12 +70,21 @@ public:
    */
   void external_gps_time_callback(const TimeReferenceMsg& time);
 
+  /**
+   * \brief Accepts external speed measurement to set speed on the device
+   * \param speed  Message containing the external speed measurement
+   */
+  void externalSpeedCallback(const InputSpeedMeasurementMsg& speed);
+
   // ZUPT subscribers
   BoolSubType filter_vel_state_sub_;
   BoolSubType filter_ang_state_sub_;
 
   // External GNSS subscriber
   TimeReferenceSubType external_gps_time_sub_;
+
+  // External speed subscriber
+  InputSpeedMeasurementSubType external_speed_sub_;
 
 private:
   // Node Information

--- a/src/microstrain_subscribers.cpp
+++ b/src/microstrain_subscribers.cpp
@@ -55,6 +55,22 @@ bool MicrostrainSubscribers::activate()
     external_gps_time_sub_ = create_subscriber<>(node_, config_->external_gps_time_topic_.c_str(), 1000,
                                                   &MicrostrainSubscribers::external_gps_time_callback, this);
   }
+
+  // Create a topic listener for external speed updates
+  if (config_->filter_enable_odometer_aiding_ &&
+      config_->inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_EF_EXTERN_SPEED_UPDATE))
+  {
+    if (!config_->enable_hardware_odometer_)
+    {
+      external_speed_sub_ = create_subscriber<>(node_, config_->external_speed_topic_.c_str(), 1000,
+                                                &MicrostrainSubscribers::externalSpeedCallback, this);
+    }
+    else
+    {
+      MICROSTRAIN_WARN(node_, "Note: Not enabling external speed subscriber as hardware odometer is enabled");
+    }
+  }
+
   return true;
 }
 
@@ -164,6 +180,24 @@ void MicrostrainSubscribers::external_gps_time_callback(const TimeReferenceMsg& 
       config_->inertial_device_->setGPSTimeUpdate(mscl::MipTypes::TimeFrame::TIME_FRAME_SECONDS, secs);
 
       MICROSTRAIN_INFO(node_, "GPS Update: w%i, s%ld", weeks, secs);
+    }
+    catch (mscl::Error& e)
+    {
+      MICROSTRAIN_ERROR(node_, "Error: %s", e.what());
+    }
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// External Speed Callback
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+void MicrostrainSubscribers::externalSpeedCallback(const InputSpeedMeasurementMsg& speed)
+{
+  if (config_->inertial_device_)
+  {
+    try
+    {
+      config_->inertial_device_->sendExternalSpeedMeasurementUpdate(speed.gps_tow, speed.speed, speed.speed_uncertainty);
     }
     catch (mscl::Error& e)
     {


### PR DESCRIPTION
* Adds set filter speed lever arm service to allow users to configure [Measurement Speed Lever Arm](https://s3.amazonaws.com/files.microstrain.com/GQ7+User+Manual/external_content/dcp/Commands/filter_command/data/mip_filter_speed_lever_arm.htm?Highlight=lever%20arm) at runtime with a service call
* Subscribes to external speed measurements
* Adds ability to configure hardware odometer at config time by sending the [Odometer Settings](https://s3.amazonaws.com/files.microstrain.com/GQ7+User+Manual/external_content/dcp/Commands/3dm_command/data/mip_cmd_3dm_odometer.htm?Highlight=odometer) command based on launch config
* Related to LORD-MicroStrain/microstrain_inertial_msgs_common#1