### PR TITLE
Only attempts to publish GNSS aiding status if the pointer has been initialized

### DIFF
--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -965,7 +965,7 @@ void MicrostrainParser::parseFilterPacket(const mscl::MipDataPacket& packet)
 
   for (i = 0; i < NUM_GNSS; i++)
   {
-    if (config_->publish_gnss_aiding_status_[i] && gnss_aiding_status_received[i])
+    if (config_->publish_gnss_[i] && config_->publish_gnss_aiding_status_[i] && gnss_aiding_status_received[i])
       publishers_->gnss_aiding_status_pub_[i]->publish(publishers_->gnss_aiding_status_msg_[i]);
   }
 

--- a/src/microstrain_publishers.cpp
+++ b/src/microstrain_publishers.cpp
@@ -63,8 +63,7 @@ bool MicrostrainPublishers::configure()
     gnss_time_pub_[GNSS1_ID] = create_publisher<TimeReferenceMsg>(node_, "gnss1/time_ref", 100);
     gnss_fix_info_pub_[GNSS1_ID] = create_publisher<GNSSFixInfoMsg>(node_, "gnss1/fix_info", 100);
 
-    if (config_->inertial_device_->features().supportsCommand(
-            mscl::MipTypes::Command::CMD_EF_AIDING_MEASUREMENT_ENABLE))
+    if (config_->publish_gnss_aiding_status_[GNSS1_ID])
     {
       gnss_aiding_status_pub_[GNSS1_ID] = create_publisher<GNSSAidingStatusMsg>(node_, "gnss1/aiding_status", 100);
     }
@@ -79,8 +78,7 @@ bool MicrostrainPublishers::configure()
     gnss_time_pub_[GNSS2_ID] = create_publisher<TimeReferenceMsg>(node_, "gnss2/time_ref", 100);
     gnss_fix_info_pub_[GNSS2_ID] = create_publisher<GNSSFixInfoMsg>(node_, "gnss2/fix_info", 100);
 
-    if (config_->inertial_device_->features().supportsCommand(
-            mscl::MipTypes::Command::CMD_EF_AIDING_MEASUREMENT_ENABLE))
+    if (config_->publish_gnss_aiding_status_[GNSS2_ID])
     {
       gnss_aiding_status_pub_[GNSS2_ID] = create_publisher<GNSSAidingStatusMsg>(node_, "gnss2/aiding_status", 100);
     }


### PR DESCRIPTION
Fixes issue where node will segfault if either `publish_gnss1` or `publish_gnss2` is set and the other is not, but the [GNSS Position Aiding Status](https://s3.amazonaws.com/files.microstrain.com/GQ7+User+Manual/external_content/dcp/Data/filter_data/data/mip_field_filter_gnss_pos_aid_status.htm?Highlight=gnss%20aiding) was set to stream on the other antenna