### PR TITLE
More granular data rates

### DIFF
--- a/config/params.yml
+++ b/config/params.yml
@@ -118,6 +118,16 @@ publish_gps_corr : False
 publish_gnss1   : True
 gnss1_data_rate : 2
 
+# The speed at which the individual GNSS1 publishers will publish at.
+#      If set to -1, will use gnss1_data_rate to determine the rate at which to stream and publish
+#      If set to 0, the stream will be turned off and the publisher will not be created
+gnss1_nav_sat_fix_data_rate    : -1  # Note that this message uses some of the same MIP fields as gnss1_odom_data_rate,
+                                     # so if one is set higher than the other, the higher rate will be the rate at which the data is published
+gnss1_odom_data_rate           : -1  # Note that this message uses some of the same MIP fields as gnss1_nav_sat_fix_data_rate,
+                                     # so if one is set higher than the other, the higher rate will be the rate at which the data is published
+gnss1_time_reference_data_rate : -1
+gnss1_fix_info_data_rate       : -1
+
 # Antenna #1 lever arm offset vector
 #     For GQ7 - in the vehicle frame wrt IMU origin (meters)
 #     For all other models - in the IMU frame wrt IMU origin (meters)
@@ -127,6 +137,16 @@ gnss1_antenna_offset : [0.0, -0.7, -1.0]
 # GNSS2 settings are only applicable for multi-GNSS systems (e.g. GQ7) 
 publish_gnss2   : True
 gnss2_data_rate : 2
+
+# The speed at which the individual GNSS2 publishers will publish at.
+#      If set to -1, will use gnss2_data_rate to determine the rate at which to stream and publish
+#      If set to 0, the stream will be turned off and the publisher will not be created
+gnss2_nav_sat_fix_data_rate    : -1  # Note that this message uses some of the same MIP fields as gnss2_odom_data_rate,
+                                     # so if one is set higher than the other, the higher rate will be the rate at which the data is published
+gnss2_odom_data_rate           : -1  # Note that this message uses some of the same MIP fields as gnss2_nav_sat_fix_data_rate,
+                                     # so if one is set higher than the other, the higher rate will be the rate at which the data is published
+gnss2_time_reference_data_rate : -1
+gnss2_fix_info_data_rate       : -1
 
 # Antenna #2 lever arm offset vector (In the vehicle frame wrt IMU origin (meters) )
 #Note: Make this as accurate as possible for good performance 

--- a/config/params.yml
+++ b/config/params.yml
@@ -94,6 +94,13 @@ raw_file_directory : "/home/your_name"
 publish_imu   : True
 imu_data_rate : 100
 
+# The speed at which the individual IMU publishers will publish at.
+#      If set to -1, will use imu_data_rate to determine the rate at which to stream and publish
+#      If set to 0, the stream will be turned off and the publisher will not be created
+imu_raw_data_rate : -1
+imu_mag_data_rate : -1
+imu_gps_corr_data_rate : -1  # Note that this is still dependent on publish_gps_corr being set to True
+
 # Static IMU message covariance values (the device does not generate these) 
 # Since internally these are std::vector we need to use the rosparam tags 
 imu_orientation_cov : [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]

--- a/config/params.yml
+++ b/config/params.yml
@@ -97,9 +97,10 @@ imu_data_rate : 100
 # The speed at which the individual IMU publishers will publish at.
 #      If set to -1, will use imu_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
-imu_raw_data_rate      : -1
-imu_mag_data_rate      : -1
-imu_gps_corr_data_rate : -1  # Note that this is still dependent on publish_gps_corr being set to True in order to publish
+imu_raw_data_rate      : -1  # Rate of imu/data topic
+imu_mag_data_rate      : -1  # Rate of mag topic
+imu_gps_corr_data_rate : -1  # Rate of gps_corr topic
+                             # Note that this is still dependent on publish_gps_corr being set to True in order to publish
 
 # Static IMU message covariance values (the device does not generate these) 
 # Since internally these are std::vector we need to use the rosparam tags 
@@ -124,10 +125,10 @@ gnss1_data_rate : 2
 #
 #      Note: The parameters' "gnss1_nav_sat_fix_data_rate", "gnss1_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-gnss1_nav_sat_fix_data_rate    : -1
-gnss1_odom_data_rate           : -1
-gnss1_time_reference_data_rate : -1
-gnss1_fix_info_data_rate       : -1
+gnss1_nav_sat_fix_data_rate    : -1  # Rate of gnss1/fix topic
+gnss1_odom_data_rate           : -1  # Rate of gnss1/odom topic
+gnss1_time_reference_data_rate : -1  # Rate of gnss1/time_ref topic
+gnss1_fix_info_data_rate       : -1  # Rate of gnss1/fix_info topic
 
 # Antenna #1 lever arm offset vector
 #     For GQ7 - in the vehicle frame wrt IMU origin (meters)
@@ -145,10 +146,10 @@ gnss2_data_rate : 2
 #
 #      Note: The parameters' "gnss2_nav_sat_fix_data_rate", "gnss2_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-gnss2_nav_sat_fix_data_rate    : -1
-gnss2_odom_data_rate           : -1
-gnss2_time_reference_data_rate : -1
-gnss2_fix_info_data_rate       : -1
+gnss2_nav_sat_fix_data_rate    : -1  # Rate of gnss2/fix topic
+gnss2_odom_data_rate           : -1  # Rate of gnss2/odom topic
+gnss2_time_reference_data_rate : -1  # Rate of gnss2/time_ref topic
+gnss2_fix_info_data_rate       : -1  # Rate of gnss2/fix_info topic
 
 # Antenna #2 lever arm offset vector (In the vehicle frame wrt IMU origin (meters) )
 #Note: Make this as accurate as possible for good performance 
@@ -162,7 +163,8 @@ rtk_dongle_enable : False
 # The speed at which the individual RTK publishers will publish at.
 #      If set to -1, will publish at 1 hz which was the default before allowing users to configure this rate
 #      If set to 0, the stream will be turned off and the publisher will not be created
-rtk_status_data_rate : -1  # Still reliant on rtk_dongle_enable being set to true to publish
+rtk_status_data_rate : -1  # Rate of rtk/status or rtk/status_v1 topics
+                           # Note that this is still reliant on rtk_dongle_enable being set to true to publish
 
 # (GQ7 Only) Allow the user to send RTCM messages to this node, and stream those messages to the GQ7
 subscribe_rtcm : False
@@ -184,17 +186,20 @@ filter_data_rate : 10
 #
 #      Note: The parameters' "filter_odom_data_rate", "filter_imu_data_rate", "filter_relative_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-filter_status_data_rate                     : -1
-filter_heading_data_rate                    : -1
-filter_heading_state_data_rate              : -1
-filter_odom_data_rate                       : -1
-filter_imu_data_rate                        : -1
-filter_relative_odom_data_rate              : -1  # Note that this is still dependent on publish_relative_position being set to True in order to publish
+filter_status_data_rate                     : -1  # Rate of nav/status topic
+filter_heading_data_rate                    : -1  # Rate of nav/heading topic
+filter_heading_state_data_rate              : -1  # Rate of nav/heading_state topic
+filter_odom_data_rate                       : -1  # Rate of nav/odom topic
+filter_imu_data_rate                        : -1  # Rate of nav/filtered_imu/data
+filter_relative_odom_data_rate              : -1  # Rate of nav/relative_pos topic and the transform between filter_frame_id and filter_child_frame_id
+                                                  # Note that this is still dependent on publish_relative_position being set to True in order to publish
                                                   # Note that this data rate will also control the rate at which the transform between "filter_frame_id" and "filter_child_frame_id" will be published at
-
-filter_aiding_status_data_rate              : -1  # Note that this is still dependent on filter_enable_gnss_pos_vel_aiding being set to True in order to publish
-filter_gnss_dual_antenna_data_rate          : -1  # Note that this is still dependent on filter_enable_gnss_heading_aiding being set to True in order to publish
-filter_aiding_measurement_summary_data_rate : -1  # Note that this is still dependent on publish_filter_aiding_measurement_summary being set to True in order to publish
+filter_aiding_status_data_rate              : -1  # Rate of gnss1/aiding_status and gnss2/aiding_status topics
+                                                  # Note that this is still dependent on filter_enable_gnss_pos_vel_aiding being set to True in order to publish
+filter_gnss_dual_antenna_data_rate          : -1  # Rate of nav/dual_antenna_status topic
+                                                  # Note that this is still dependent on filter_enable_gnss_heading_aiding being set to True in order to publish
+filter_aiding_measurement_summary_data_rate : -1  # Rate of nav/aiding_summary topic
+                                                  # Note that this is still dependent on publish_filter_aiding_measurement_summary being set to True in order to publish
 
 # Sensor2vehicle frame transformation selector
 #     0 = None, 1 = Euler Angles, 2 - matrix, 3 - quaternion

--- a/config/params.yml
+++ b/config/params.yml
@@ -157,6 +157,11 @@ gnss2_antenna_offset : [0.0, 0.7, -1.0]
 #   on the version of the RTK dongle connected to the GQ7
 rtk_dongle_enable : False
 
+# The speed at which the individual RTK publishers will publish at.
+#      If set to -1, will publish at 1 hz which was the default before allowing users to configure this rate
+#      If set to 0, the stream will be turned off and the publisher will not be created
+rtk_status_data_rate : -1  # Still reliant on rtk_dongle_enable being set to true to publish
+
 # (GQ7 Only) Allow the user to send RTCM messages to this node, and stream those messages to the GQ7
 subscribe_rtcm : False
 rtcm_topic     : "/rtcm"

--- a/config/params.yml
+++ b/config/params.yml
@@ -97,9 +97,9 @@ imu_data_rate : 100
 # The speed at which the individual IMU publishers will publish at.
 #      If set to -1, will use imu_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
-imu_raw_data_rate : -1
-imu_mag_data_rate : -1
-imu_gps_corr_data_rate : -1  # Note that this is still dependent on publish_gps_corr being set to True
+imu_raw_data_rate      : -1
+imu_mag_data_rate      : -1
+imu_gps_corr_data_rate : -1  # Note that this is still dependent on publish_gps_corr being set to True in order to publish
 
 # Static IMU message covariance values (the device does not generate these) 
 # Since internally these are std::vector we need to use the rosparam tags 
@@ -121,10 +121,11 @@ gnss1_data_rate : 2
 # The speed at which the individual GNSS1 publishers will publish at.
 #      If set to -1, will use gnss1_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
-gnss1_nav_sat_fix_data_rate    : -1  # Note that this message uses some of the same MIP fields as gnss1_odom_data_rate,
-                                     # so if one is set higher than the other, the higher rate will be the rate at which the data is published
-gnss1_odom_data_rate           : -1  # Note that this message uses some of the same MIP fields as gnss1_nav_sat_fix_data_rate,
-                                     # so if one is set higher than the other, the higher rate will be the rate at which the data is published
+#
+#      Note: The parameters' "gnss1_nav_sat_fix_data_rate", "gnss1_odom_data_rate" associated ROS messages share several MIP fields,
+#            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
+gnss1_nav_sat_fix_data_rate    : -1
+gnss1_odom_data_rate           : -1
 gnss1_time_reference_data_rate : -1
 gnss1_fix_info_data_rate       : -1
 
@@ -141,10 +142,11 @@ gnss2_data_rate : 2
 # The speed at which the individual GNSS2 publishers will publish at.
 #      If set to -1, will use gnss2_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
-gnss2_nav_sat_fix_data_rate    : -1  # Note that this message uses some of the same MIP fields as gnss2_odom_data_rate,
-                                     # so if one is set higher than the other, the higher rate will be the rate at which the data is published
-gnss2_odom_data_rate           : -1  # Note that this message uses some of the same MIP fields as gnss2_nav_sat_fix_data_rate,
-                                     # so if one is set higher than the other, the higher rate will be the rate at which the data is published
+#
+#      Note: The parameters' "gnss2_nav_sat_fix_data_rate", "gnss2_odom_data_rate" associated ROS messages share several MIP fields,
+#            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
+gnss2_nav_sat_fix_data_rate    : -1
+gnss2_odom_data_rate           : -1
 gnss2_time_reference_data_rate : -1
 gnss2_fix_info_data_rate       : -1
 
@@ -175,6 +177,24 @@ publish_nmea   : False
 
 publish_filter   : True
 filter_data_rate : 10
+
+# The speed at which the individual Filter publishers will publish at.
+#      If set to -1, will use filter_data_rate to determine the rate at which to stream and publish
+#      If set to 0, the stream will be turned off and the publisher will not be created
+#
+#      Note: The parameters' "filter_odom_data_rate", "filter_imu_data_rate", "filter_relative_odom_data_rate" associated ROS messages share several MIP fields,
+#            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
+filter_status_data_rate                     : -1
+filter_heading_data_rate                    : -1
+filter_heading_state_data_rate              : -1
+filter_odom_data_rate                       : -1
+filter_imu_data_rate                        : -1
+filter_relative_odom_data_rate              : -1  # Note that this is still dependent on publish_relative_position being set to True in order to publish
+                                                  # Note that this data rate will also control the rate at which the transform between "filter_frame_id" and "filter_child_frame_id" will be published at
+
+filter_aiding_status_data_rate              : -1  # Note that this is still dependent on filter_enable_gnss_pos_vel_aiding being set to True in order to publish
+filter_gnss_dual_antenna_data_rate          : -1  # Note that this is still dependent on filter_enable_gnss_heading_aiding being set to True in order to publish
+filter_aiding_measurement_summary_data_rate : -1  # Note that this is still dependent on publish_filter_aiding_measurement_summary being set to True in order to publish
 
 # Sensor2vehicle frame transformation selector
 #     0 = None, 1 = Euler Angles, 2 - matrix, 3 - quaternion

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -132,6 +132,12 @@ public:
   bool configureFilter(RosNodeType* node);
 
   /**
+   * \brief Configures Filter data rates on the inertial device. This is where the data being published will actually be setup to stream or disabled
+   * \return true if the data rates were configured and false if an error occured
+   */
+  bool configureFilterDataRates();
+
+  /**
    * \brief Configures Sensor 2 Vehicle settings on the inertial device
    * \param node  The ROS node that contains configuration information. For ROS1 this is the private node handle ("~")
    * \return true if configuration was successful and false if configuration failed
@@ -175,6 +181,7 @@ public:
   bool filter_enable_wheeled_vehicle_constraint_;
   bool filter_enable_vertical_gyro_constraint_;
   bool filter_enable_gnss_antenna_cal_;
+  bool filter_use_compensated_accel_;
 
   // Frame ids
   std::string imu_frame_id_;
@@ -193,10 +200,10 @@ public:
   bool publish_imu_;
   bool publish_gps_corr_;
   bool publish_gnss_[NUM_GNSS];
-  bool publish_gnss_aiding_status_[NUM_GNSS];
   bool publish_gnss_dual_antenna_status_;
   bool publish_filter_;
   bool publish_filter_relative_pos_;
+  bool publish_filter_aiding_status_;
   bool publish_filter_aiding_measurement_summary_;
   bool publish_rtk_;
   bool publish_nmea_;
@@ -228,7 +235,6 @@ public:
   int gnss_nav_sat_fix_data_rate_[NUM_GNSS];
   int gnss_odom_data_rate_[NUM_GNSS];
   int gnss_time_reference_data_rate_[NUM_GNSS];
-  int gnss_aiding_status_data_rate_[NUM_GNSS];  // TODO: This is really filter data, so do this when we setup multiple filter rates
   int gnss_fix_info_data_rate_[NUM_GNSS];
 
   // RTK update rates
@@ -238,11 +244,12 @@ public:
   int filter_status_data_rate_;
   int filter_heading_data_rate_;
   int filter_heading_state_data_rate_;
-  int filter_aiding_measurement_summary_data_rate_;
   int filter_odom_data_rate_;
   int filter_imu_data_rate_;
   int filter_relative_odom_data_rate_;  // Note that this will be used for both the relative odometry message and the transform published on the /tf topic
+  int filter_aiding_status_data_rate_;
   int filter_gnss_dual_antenna_status_data_rate_;
+  int filter_aiding_measurement_summary_data_rate_;
 
   // Gnss antenna offsets
   std::vector<double> gnss_antenna_offset_[NUM_GNSS];

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -91,7 +91,7 @@ public:
   bool configureIMU(RosNodeType* node);
 
   /**
-   * \brief Configures IMU data rates on the inertial device. This is where the data being published will actually be setup to stream or disabled
+   * \brief Configures IMU data rates on the inertial device. This is where the data being published will actually be disabled or setup to stream
    * \return true if the data rates were configured and false if an error occured
    */
   bool configureIMUDataRates();
@@ -105,7 +105,7 @@ public:
   bool configureGNSS(RosNodeType* node, uint8_t gnss_id);
 
   /**
-   * \brief Configures GNSS1 data rates on the inertial device. This is where the data being published will actually be setup to stream or disabled
+   * \brief Configures GNSS1 data rates on the inertial device. This is where the data being published will actually be disabled or setup to stream
    * \param gnss_id  The ID of the GNSS receiver that we want to configure
    * \return true if the data rates were configured and false if an error occured
    */
@@ -119,7 +119,7 @@ public:
   bool configureRTK(RosNodeType* node);
 
   /**
-   * \brief Configures RTK data rates on the inertial device. This is where the data being published will actually be setup to stream or disabled
+   * \brief Configures RTK data rates on the inertial device. This is where the data being published will actually be disabled or setup to stream
    * \return true if the data rates were configured and false if an error occured
    */
   bool configureRTKDataRates();
@@ -132,7 +132,7 @@ public:
   bool configureFilter(RosNodeType* node);
 
   /**
-   * \brief Configures Filter data rates on the inertial device. This is where the data being published will actually be setup to stream or disabled
+   * \brief Configures Filter data rates on the inertial device. This is where the data being published will actually be disabled or setup to stream
    * \return true if the data rates were configured and false if an error occured
    */
   bool configureFilterDataRates();

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -99,9 +99,17 @@ public:
   /**
    * \brief Configures GNSS settings on the inertial device
    * \param node  The ROS node that contains configuration information. For ROS1 this is the private node handle ("~")
+   * \param gnss_id  The ID of the GNSS receiver that we want to configure
    * \return true if configuration was successful and false if configuration failed
    */
   bool configureGNSS(RosNodeType* node, uint8_t gnss_id);
+
+  /**
+   * \brief Configures GNSS1 data rates on the inertial device. This is where the data being published will actually be setup to stream or disabled
+   * \param gnss_id  The ID of the GNSS receiver that we want to configure
+   * \return true if the data rates were configured and false if an error occured
+   */
+  bool configureGNSSDataRates(uint8_t gnss_id);
 
   /**
    * \brief Configures RTK settings on the inertial device
@@ -214,7 +222,7 @@ public:
   int gnss_nav_sat_fix_data_rate_[NUM_GNSS];
   int gnss_odom_data_rate_[NUM_GNSS];
   int gnss_time_reference_data_rate_[NUM_GNSS];
-  int gnss_aiding_status_data_rate_[NUM_GNSS];
+  int gnss_aiding_status_data_rate_[NUM_GNSS];  // TODO: This is really filter data, so do this when we setup multiple filter rates
   int gnss_fix_info_data_rate_[NUM_GNSS];
 
   // RTK update rates

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -30,6 +30,8 @@ const std::vector<double> DEFAULT_MATRIX = { 9.0, 0.0 };
 const std::vector<double> DEFAULT_VECTOR = { 3.0, 0.0 };
 const std::vector<double> DEFAULT_QUATERNION = { 4.0, 0.0 };
 
+static constexpr int DEFAULT_DATA_RATE = -1;  // If a data rate is set to this, the data rate will be set to the default data rate
+
 /**
  * Contains configuration information for the node, configures the device on startup
  *  This class holds the pointer to the MSCL device, so any communication to the device should be done through this class
@@ -232,24 +234,24 @@ public:
   int imu_gps_corr_data_rate_;
 
   // GNSS update rates
-  int gnss_nav_sat_fix_data_rate_[NUM_GNSS];
-  int gnss_odom_data_rate_[NUM_GNSS];
-  int gnss_time_reference_data_rate_[NUM_GNSS];
-  int gnss_fix_info_data_rate_[NUM_GNSS];
+  int gnss_nav_sat_fix_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
+  int gnss_odom_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
+  int gnss_time_reference_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
+  int gnss_fix_info_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
 
   // RTK update rates
-  int rtk_status_data_rate_;  // Note that this will be used for both the RTKv1 and RTKv2 status messages
+  int rtk_status_data_rate_ = DEFAULT_DATA_RATE;  // Note that this will be used for both the RTKv1 and RTKv2 status messages
 
   // Filter update rates
-  int filter_status_data_rate_;
-  int filter_heading_data_rate_;
-  int filter_heading_state_data_rate_;
-  int filter_odom_data_rate_;
-  int filter_imu_data_rate_;
-  int filter_relative_odom_data_rate_;  // Note that this will be used for both the relative odometry message and the transform published on the /tf topic
-  int filter_aiding_status_data_rate_;
-  int filter_gnss_dual_antenna_status_data_rate_;
-  int filter_aiding_measurement_summary_data_rate_;
+  int filter_status_data_rate_ = DEFAULT_DATA_RATE;
+  int filter_heading_data_rate_ = DEFAULT_DATA_RATE;
+  int filter_heading_state_data_rate_ = DEFAULT_DATA_RATE;
+  int filter_odom_data_rate_ = DEFAULT_DATA_RATE;
+  int filter_imu_data_rate_ = DEFAULT_DATA_RATE;
+  int filter_relative_odom_data_rate_ = DEFAULT_DATA_RATE;  // Note that this will be used for both the relative odometry message and the transform published on the /tf topic
+  int filter_aiding_status_data_rate_ = DEFAULT_DATA_RATE;
+  int filter_gnss_dual_antenna_status_data_rate_ = DEFAULT_DATA_RATE;
+  int filter_aiding_measurement_summary_data_rate_ = DEFAULT_DATA_RATE;
 
   // Gnss antenna offsets
   std::vector<double> gnss_antenna_offset_[NUM_GNSS];

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -119,6 +119,12 @@ public:
   bool configureRTK(RosNodeType* node);
 
   /**
+   * \brief Configures RTK data rates on the inertial device. This is where the data being published will actually be setup to stream or disabled
+   * \return true if the data rates were configured and false if an error occured
+   */
+  bool configureRTKDataRates();
+
+  /**
    * \brief Configures Filter settings on the inertial device
    * \param node  The ROS node that contains configuration information. For ROS1 this is the private node handle ("~")
    * \return true if configuration was successful and false if configuration failed

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -91,6 +91,12 @@ public:
   bool configureIMU(RosNodeType* node);
 
   /**
+   * \brief Configures IMU data rates on the inertial device. This is where the data being published will actually be setup to stream or disabled
+   * \return true if the data rates were configured and false if an error occured
+   */
+  bool configureIMUDataRates();
+
+  /**
    * \brief Configures GNSS settings on the inertial device
    * \param node  The ROS node that contains configuration information. For ROS1 this is the private node handle ("~")
    * \return true if configuration was successful and false if configuration failed
@@ -199,6 +205,31 @@ public:
   int gnss_data_rate_[NUM_GNSS];
   int filter_data_rate_;
 
+  // IMU update rates
+  int imu_raw_data_rate_;
+  int imu_mag_data_rate_;
+  int imu_gps_corr_data_rate_;
+
+  // GNSS update rates
+  int gnss_nav_sat_fix_data_rate_[NUM_GNSS];
+  int gnss_odom_data_rate_[NUM_GNSS];
+  int gnss_time_reference_data_rate_[NUM_GNSS];
+  int gnss_aiding_status_data_rate_[NUM_GNSS];
+  int gnss_fix_info_data_rate_[NUM_GNSS];
+
+  // RTK update rates
+  int rtk_status_data_rate_;  // Note that this will be used for both the RTKv1 and RTKv2 status messages
+
+  // Filter update rates
+  int filter_status_data_rate_;
+  int filter_heading_data_rate_;
+  int filter_heading_state_data_rate_;
+  int filter_aiding_measurement_summary_data_rate_;
+  int filter_odom_data_rate_;
+  int filter_imu_data_rate_;
+  int filter_relative_odom_data_rate_;  // Note that this will be used for both the relative odometry message and the transform published on the /tf topic
+  int filter_gnss_dual_antenna_status_data_rate_;
+
   // Gnss antenna offsets
   std::vector<double> gnss_antenna_offset_[NUM_GNSS];
 
@@ -227,6 +258,25 @@ public:
   std::ofstream raw_file_;
 
 private:
+  /**
+   * \brief Gets the raw value of a data rate parameter, or populates the parameter with the default data rate if it is set to the default value
+   * \param node  The ROS node that contains configuration information. For ROS1 this is the private node handle ("~")
+   * \param key  The key to look for in the config for the data rate param
+   * \param data_rate  The data rate value to populate with the config parameter
+   * \param default_data_rate  The value to set data_rate to if it is set to -1
+   */
+  static void getDataRateParam(RosNodeType* node, const std::string& key, int& data_rate, int default_data_rate);
+
+  /**
+   * \brief Configures Sensor 2 Vehicle settings on the inertial device
+   * \param data_class  The data class that the channels in channel_fields belong to
+   * \param channel_fields  The channel fields to set to stream at the requested data_rate
+   * \param data_rate  The rate in hertz to stream the MIP data at
+   * \param channels_to_stream  List of channels and their associated rate that will be populated with the proper channels and data rates
+   */
+  void getSupportedMipChannels(mscl::MipTypes::DataClass data_class, const mscl::MipTypes::MipChannelFields& channel_fields, int data_rate, mscl::MipChannels* channels_to_stream);
+  
+  // Handle to the ROS node
   RosNodeType* node_;
 };  // MicrostrainConfig class
 

--- a/include/microstrain_inertial_driver_common/microstrain_publishers.h
+++ b/include/microstrain_inertial_driver_common/microstrain_publishers.h
@@ -53,11 +53,11 @@ public:
   GPSCorrelationTimestampStampedPubType gps_corr_pub_ = nullptr;
 
   // GNSS Publishers
-  NavSatFixPubType gnss_pub_[NUM_GNSS];
-  OdometryPubType gnss_odom_pub_[NUM_GNSS];
-  TimeReferencePubType gnss_time_pub_[NUM_GNSS];
-  GNSSAidingStatusPubType gnss_aiding_status_pub_[NUM_GNSS];
-  GNSSFixInfoPubType gnss_fix_info_pub_[NUM_GNSS];
+  NavSatFixPubType gnss_pub_[NUM_GNSS] = { nullptr };
+  OdometryPubType gnss_odom_pub_[NUM_GNSS] = { nullptr };
+  TimeReferencePubType gnss_time_pub_[NUM_GNSS] = { nullptr };
+  GNSSAidingStatusPubType gnss_aiding_status_pub_[NUM_GNSS] = { nullptr };
+  GNSSFixInfoPubType gnss_fix_info_pub_[NUM_GNSS] = { nullptr };
 
   // RTK Data publisher
   RTKStatusPubType rtk_pub_;

--- a/include/microstrain_inertial_driver_common/microstrain_publishers.h
+++ b/include/microstrain_inertial_driver_common/microstrain_publishers.h
@@ -64,14 +64,14 @@ public:
   RTKStatusPubTypeV1 rtk_pub_v1_ = nullptr;
 
   // Filter Publishers
-  FilterStatusPubType filter_status_pub_;
-  FilterHeadingPubType filter_heading_pub_;
-  FilterHeadingStatePubType filter_heading_state_pub_;
-  FilterAidingMeasurementSummaryPubType filter_aiding_measurement_summary_pub_;
-  OdometryPubType filter_pub_;
-  ImuPubType filtered_imu_pub_;
-  OdometryPubType filter_relative_pos_pub_;
-  GNSSDualAntennaStatusPubType gnss_dual_antenna_status_pub_;
+  FilterStatusPubType filter_status_pub_ = nullptr;
+  FilterHeadingPubType filter_heading_pub_ = nullptr;
+  FilterHeadingStatePubType filter_heading_state_pub_ = nullptr;
+  FilterAidingMeasurementSummaryPubType filter_aiding_measurement_summary_pub_ = nullptr;
+  OdometryPubType filter_pub_ = nullptr;
+  ImuPubType filtered_imu_pub_ = nullptr;
+  OdometryPubType filter_relative_pos_pub_ = nullptr;
+  GNSSDualAntennaStatusPubType gnss_dual_antenna_status_pub_ = nullptr;
 
   // Device Status Publisher
   StatusPubType device_status_pub_;
@@ -80,7 +80,7 @@ public:
   NMEASentencePubType nmea_sentence_pub_;
 
   // Transform Broadcaster
-  TransformBroadcasterType transform_broadcaster_;
+  TransformBroadcasterType transform_broadcaster_ = nullptr;
 
   // IMU Messages
   ImuMsg imu_msg_;

--- a/include/microstrain_inertial_driver_common/microstrain_publishers.h
+++ b/include/microstrain_inertial_driver_common/microstrain_publishers.h
@@ -48,9 +48,9 @@ public:
   void publishDeviceStatus();
 
   // IMU Publishers
-  ImuPubType imu_pub_;
-  MagneticFieldPubType mag_pub_;
-  GPSCorrelationTimestampStampedPubType gps_corr_pub_;
+  ImuPubType imu_pub_ = nullptr;
+  MagneticFieldPubType mag_pub_ = nullptr;
+  GPSCorrelationTimestampStampedPubType gps_corr_pub_ = nullptr;
 
   // GNSS Publishers
   NavSatFixPubType gnss_pub_[NUM_GNSS];

--- a/include/microstrain_inertial_driver_common/microstrain_publishers.h
+++ b/include/microstrain_inertial_driver_common/microstrain_publishers.h
@@ -60,8 +60,8 @@ public:
   GNSSFixInfoPubType gnss_fix_info_pub_[NUM_GNSS] = { nullptr };
 
   // RTK Data publisher
-  RTKStatusPubType rtk_pub_;
-  RTKStatusPubTypeV1 rtk_pub_v1_;
+  RTKStatusPubType rtk_pub_ = nullptr;
+  RTKStatusPubTypeV1 rtk_pub_v1_ = nullptr;
 
   // Filter Publishers
   FilterStatusPubType filter_status_pub_;

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -1039,7 +1039,7 @@ bool MicrostrainConfig::configureFilter(RosNodeType* node)
   publish_filter_aiding_status_ = inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_EF_AIDING_MEASUREMENT_ENABLE);
   if (!publish_filter_aiding_status_)
   {
-    MICROSTRAIN_INFO(node_, "Note: Device not support publishing GNSS Aiding measurements.");
+    MICROSTRAIN_INFO(node_, "Note: The device does not support publishing GNSS Aiding measurements.");
   }
   return true;
 }

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -20,8 +20,6 @@
 #include <memory>
 #include "microstrain_inertial_driver_common/microstrain_config.h"
 
-static constexpr int DEFAULT_DATA_RATE = -1;  // If a data rate is set to this, the data rate will be set to the default data rate
-
 namespace microstrain
 {
 MicrostrainConfig::MicrostrainConfig(RosNodeType* node) : node_(node)

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -130,6 +130,18 @@ bool MicrostrainConfig::configure(RosNodeType* node)
   get_param<std::string>(node, "filter_external_gps_time_topic", external_gps_time_topic_,
                          std::string("/external_gps_time"));
   get_param<std::string>(node, "filter_external_speed_topic", external_speed_topic_, "/external_speed");
+  get_param<bool>(node, "filter_use_compensated_accel", filter_use_compensated_accel_, true);
+
+  // Filter Data Rates
+  getDataRateParam(node, "filter_status_data_rate", filter_status_data_rate_, filter_data_rate_);
+  getDataRateParam(node, "filter_heading_data_rate", filter_heading_data_rate_, filter_data_rate_);
+  getDataRateParam(node, "filter_heading_state_data_rate", filter_heading_state_data_rate_, filter_data_rate_);
+  getDataRateParam(node, "filter_aiding_measurement_summary_data_rate", filter_aiding_measurement_summary_data_rate_, filter_data_rate_);
+  getDataRateParam(node, "filter_odom_data_rate", filter_odom_data_rate_, filter_data_rate_);
+  getDataRateParam(node, "filter_imu_data_rate", filter_imu_data_rate_, filter_data_rate_);
+  getDataRateParam(node, "filter_relative_odom_data_rate", filter_relative_odom_data_rate_, filter_data_rate_);
+  getDataRateParam(node, "filter_gnss_dual_antenna_status_data_rate", filter_gnss_dual_antenna_status_data_rate_, filter_data_rate_);
+  getDataRateParam(node, "filter_aiding_status_data_rate", filter_aiding_status_data_rate_, filter_data_rate_);
 
   // Enable dual antenna messages
   publish_gnss_dual_antenna_status_ = filter_enable_gnss_heading_aiding_;
@@ -336,10 +348,14 @@ bool MicrostrainConfig::setupDevice(RosNodeType* node)
   }
 
   // Filter setup
-  if (publish_filter_ && supports_filter_)
+  if (supports_filter_)
   {
     if (!configureFilter(node))
       return false;
+
+    if (publish_filter_)
+      if (!configureFilterDataRates())
+        return false;
   }
 
   // Sensor2Vehicle setup
@@ -592,7 +608,7 @@ bool MicrostrainConfig::configureGNSS(RosNodeType* node, uint8_t gnss_id)
 
 bool MicrostrainConfig::configureGNSSDataRates(uint8_t gnss_id)
 {
-  // If this is true, we will use GNSS1_* fields, otherwise we will use GNSS_* fields
+  // If this is true, we will use GNSS_1_* fields, otherwise we will use GNSS_* fields
   const bool multi_gnss = inertial_device_->features().supportsCategory(mscl::MipTypes::DataClass::CLASS_GNSS1);
 
   // Will be populated with different values depending on the GNSS ID
@@ -731,7 +747,6 @@ bool MicrostrainConfig::configureRTKDataRates()
     return false;
   }
   return true;
-
 }
 
 bool MicrostrainConfig::configureFilter(RosNodeType* node)
@@ -741,13 +756,11 @@ bool MicrostrainConfig::configureFilter(RosNodeType* node)
   float initial_heading;
   bool filter_auto_init = true;
   int dynamics_mode;
-  bool filter_use_compensated_accel;
   float hardware_odometer_scaling;
   float hardware_odometer_uncertainty;
   get_param<int32_t>(node, "filter_heading_source", heading_source, 0x1);
   get_param<float>(node, "filter_initial_heading", initial_heading, 0.0);
   get_param<bool>(node, "filter_auto_init", filter_auto_init, true);
-  get_param<bool>(node, "filter_use_compensated_accel", filter_use_compensated_accel, true);
   get_param<int32_t>(node, "filter_dynamics_mode", dynamics_mode, 1);
   get_param<float>(node, "odometer_scaling", hardware_odometer_scaling, 0.0);
   get_param<float>(node, "odometer_uncertainty", hardware_odometer_uncertainty, 0.0);
@@ -779,52 +792,6 @@ bool MicrostrainConfig::configureFilter(RosNodeType* node)
   get_param<std::vector<double>>(node, "filter_speed_lever_arm", filter_speed_lever_arm, DEFAULT_VECTOR);
   get_param<double>(node, "filter_gnss_antenna_cal_max_offset", filter_gnss_antenna_cal_max_offset, 0.1);
   get_param<int32_t>(node, "filter_pps_source", filter_pps_source, 1);
-
-  mscl::SampleRate filter_rate = mscl::SampleRate::Hertz(filter_data_rate_);
-
-  MICROSTRAIN_INFO(node_, "Setting Filter data to stream at %d hz", filter_data_rate_);
-
-  mscl::MipTypes::MipChannelFields navChannels
-  {
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_GPS_TIMESTAMP,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_FILTER_STATUS,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_LLH_POS,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_NED_VELOCITY,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ORIENT_QUATERNION,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_LLH_UNCERT,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_NED_UNCERT,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ATT_UNCERT_QUAT,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ANGULAR_RATE,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ATT_UNCERT_EULER,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ORIENT_EULER,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_HEADING_UPDATE_SOURCE,
-    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_NED_RELATIVE_POS
-  };
-
-  // Add one or the other types of acceleration depending on the configuration
-  if (filter_use_compensated_accel)
-    navChannels.push_back(mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_COMPENSATED_ACCEL);
-  else
-    navChannels.push_back(mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_LINEAR_ACCEL);
-
-  if (filter_enable_gnss_pos_vel_aiding_)
-    navChannels.push_back(mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_POSITION_AIDING_STATUS);
-  if (filter_enable_gnss_heading_aiding_)
-    navChannels.push_back(mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_GNSS_DUAL_ANTENNA_STATUS);
-  if (publish_filter_aiding_measurement_summary_)
-    navChannels.push_back(mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_AIDING_MEASURE_SUMMARY);
-
-  mscl::MipChannels supportedChannels;
-  for (mscl::MipTypes::ChannelField channel :
-       inertial_device_->features().supportedChannelFields(mscl::MipTypes::DataClass::CLASS_ESTFILTER))
-  {
-    if (std::find(navChannels.begin(), navChannels.end(), channel) != navChannels.end())
-    {
-      supportedChannels.push_back(mscl::MipChannel(channel, filter_rate));
-    }
-  }
-
-  inertial_device_->setActiveChannelFields(mscl::MipTypes::DataClass::CLASS_ESTFILTER, supportedChannels);
 
   // set dynamics mode
   if (inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_EF_VEHIC_DYNAMICS_MODE))
@@ -1068,8 +1035,118 @@ bool MicrostrainConfig::configureFilter(RosNodeType* node)
     MICROSTRAIN_INFO(node_, "Note: The device does not support the odometer settings command");
   }
 
-  // Enable the filter datastream
-  inertial_device_->enableDataStream(mscl::MipTypes::DataClass::CLASS_ESTFILTER);
+  // Whether or not we can enable heading status
+  publish_filter_aiding_status_ = inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_EF_AIDING_MEASUREMENT_ENABLE);
+  if (!publish_filter_aiding_status_)
+  {
+    MICROSTRAIN_INFO(node_, "Note: Device not support publishing GNSS Aiding measurements.");
+  }
+  return true;
+}
+
+bool MicrostrainConfig::configureFilterDataRates()
+{
+  mscl::MipChannels channels_to_stream;
+
+  // Streaming for /nav/status
+  mscl::MipTypes::MipChannelFields filter_status_fields
+  {
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_FILTER_STATUS,
+  };
+  getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_status_fields, filter_status_data_rate_, &channels_to_stream);
+
+  // Streaming for /nav/heading
+  mscl::MipTypes::MipChannelFields filter_heading_fields
+  {
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ORIENT_EULER,
+  };
+  getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_heading_fields, filter_heading_data_rate_, &channels_to_stream);
+
+  // Streaming for /nav/heading_state
+  mscl::MipTypes::MipChannelFields filter_heading_state_fields
+  {
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_HEADING_UPDATE_SOURCE,
+  };
+  getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_heading_state_fields, filter_heading_state_data_rate_, &channels_to_stream);
+
+  // Streaming for /nav/odom
+  mscl::MipTypes::MipChannelFields filter_odom_fields
+  {
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_LLH_POS,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_LLH_UNCERT,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ORIENT_QUATERNION,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ATT_UNCERT_EULER,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_NED_VELOCITY,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_NED_UNCERT,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ANGULAR_RATE,
+  };
+  getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_odom_fields, filter_odom_data_rate_, &channels_to_stream);
+
+  // Streaming for /nav/filtered_imu
+  mscl::MipTypes::MipChannelFields filter_imu_fields
+  {
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ORIENT_QUATERNION,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ANGULAR_RATE,
+    filter_use_compensated_accel_ ? mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_COMPENSATED_ACCEL : mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_LINEAR_ACCEL,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ATT_UNCERT_EULER,
+  };
+  getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_imu_fields, filter_imu_data_rate_, &channels_to_stream);
+
+  // Streaming for /nav/relative_pos/odom
+  mscl::MipTypes::MipChannelFields filter_relative_odom_fields
+  {
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_NED_RELATIVE_POS,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_LLH_UNCERT,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ORIENT_QUATERNION,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ATT_UNCERT_EULER,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_NED_VELOCITY,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_NED_UNCERT,
+    mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_ESTIMATED_ANGULAR_RATE,
+  };
+  getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_relative_odom_fields, filter_relative_odom_data_rate_, &channels_to_stream);
+
+  // Streaming for /gnss*/aiding_status
+  if (filter_enable_gnss_pos_vel_aiding_)
+  {
+    mscl::MipTypes::MipChannelFields filter_aiding_status_fields
+    {
+      mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_POSITION_AIDING_STATUS,
+    };
+    getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_aiding_status_fields, filter_aiding_status_data_rate_, &channels_to_stream);
+  }
+  
+  // Streaming for /nav/dual_antenna_status
+  if (filter_enable_gnss_heading_aiding_)
+  {
+    mscl::MipTypes::MipChannelFields filter_gnss_dual_antenna_status_fields
+    {
+      mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_GNSS_DUAL_ANTENNA_STATUS,
+    };
+    getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_gnss_dual_antenna_status_fields, filter_gnss_dual_antenna_status_data_rate_, &channels_to_stream);
+  }
+
+  // Streaming for /nav/aiding_summary
+  if (publish_filter_aiding_measurement_summary_)
+  {
+    mscl::MipTypes::MipChannelFields filter_aiding_measurement_summary_fields
+    {
+      mscl::MipTypes::ChannelField::CH_FIELD_ESTFILTER_AIDING_MEASURE_SUMMARY
+    };
+    getSupportedMipChannels(mscl::MipTypes::DataClass::CLASS_ESTFILTER, filter_aiding_measurement_summary_fields, filter_aiding_measurement_summary_data_rate_, &channels_to_stream);
+  }
+
+  // Enable the data stream
+  try
+  {
+    inertial_device_->setActiveChannelFields(mscl::MipTypes::DataClass::CLASS_ESTFILTER, channels_to_stream);
+    inertial_device_->enableDataStream(mscl::MipTypes::DataClass::CLASS_ESTFILTER);
+  }
+  catch (const mscl::Error& e)
+  {
+    MICROSTRAIN_ERROR(node_, "Unable to set filter data to stream.");
+    MICROSTRAIN_ERROR(node_, "  Error: %s", e.what());
+    return false;
+  }
   return true;
 }
 
@@ -1239,8 +1316,28 @@ void MicrostrainConfig::getSupportedMipChannels(mscl::MipTypes::DataClass data_c
   {
     if (std::find(supported_channels.begin(), supported_channels.end(), channel) != supported_channels.end())
     {
-      MICROSTRAIN_DEBUG(node_, "Streaming MIP field with descriptor 0x%x at a rate of %d hz", static_cast<uint16_t>(channel), data_rate);
-      channels_to_stream->push_back(mscl::MipChannel(channel, data_rate_hz));
+      // If the channel has already been added, only add this if the requested rate is higher, otherwise just update the rate
+      auto existing_channel = std::find_if(channels_to_stream->begin(), channels_to_stream->end(), [channel](const mscl::MipChannel& m)
+      {
+        return m.channelField() == channel;
+      });
+      if (existing_channel != channels_to_stream->end())
+      {
+        if (existing_channel->sampleRate() < data_rate_hz)
+        {
+          MICROSTRAIN_DEBUG(node_, "Updating MIP field with descriptor 0x%x to stream at %d hz", static_cast<uint16_t>(channel), data_rate);
+          *existing_channel = mscl::MipChannel(channel, data_rate_hz);
+        }
+        else
+        {
+          MICROSTRAIN_DEBUG(node_, "MIP field with descriptor 0x%x is already streaming faster than %d hz, so we are not updating it", static_cast<uint16_t>(channel), data_rate);
+        }
+      }
+      else
+      {
+        MICROSTRAIN_DEBUG(node_, "Streaming MIP field with descriptor 0x%x at a rate of %d hz", static_cast<uint16_t>(channel), data_rate);
+        channels_to_stream->push_back(mscl::MipChannel(channel, data_rate_hz));
+      }
     }
     else
     {

--- a/src/microstrain_node_base.cpp
+++ b/src/microstrain_node_base.cpp
@@ -83,10 +83,42 @@ bool MicrostrainNodeBase::configure(RosNodeType* config_node)
   // Determine loop rate as 2*(max update rate), but abs. max of 1kHz
   int max_rate = std::max(
     {
-      config_.publish_imu_ ? config_.imu_data_rate_ : 1,
-      config_.publish_gnss_[GNSS1_ID] ? config_.gnss_data_rate_[GNSS1_ID] : 1,
-      config_.publish_gnss_[GNSS2_ID] ? config_.gnss_data_rate_[GNSS2_ID] : 1,
-      config_.publish_filter_ ? config_.filter_data_rate_ : 1
+      config_.publish_imu_ ? std::max(
+        {
+          config_.imu_raw_data_rate_,
+          config_.imu_mag_data_rate_,
+          config_.imu_gps_corr_data_rate_,
+        }
+      ) : 1,
+      config_.publish_gnss_[GNSS1_ID] ? std::max(
+        {
+          config_.gnss_nav_sat_fix_data_rate_[GNSS1_ID],
+          config_.gnss_odom_data_rate_[GNSS1_ID],
+          config_.gnss_time_reference_data_rate_[GNSS1_ID],
+          config_.gnss_fix_info_data_rate_[GNSS1_ID],
+        }
+      ) : 1,
+      config_.publish_gnss_[GNSS2_ID] ? std::max(
+        {
+          config_.gnss_nav_sat_fix_data_rate_[GNSS2_ID],
+          config_.gnss_odom_data_rate_[GNSS2_ID],
+          config_.gnss_time_reference_data_rate_[GNSS2_ID],
+          config_.gnss_fix_info_data_rate_[GNSS2_ID],
+        }
+      ) : 1,
+      config_.publish_filter_ ? std::max(
+        {
+          config_.filter_status_data_rate_,
+          config_.filter_heading_data_rate_,
+          config_.filter_heading_state_data_rate_,
+          config_.filter_odom_data_rate_,
+          config_.filter_imu_data_rate_,
+          config_.filter_relative_odom_data_rate_,
+          config_.filter_aiding_status_data_rate_,
+          config_.filter_gnss_dual_antenna_status_data_rate_,
+          config_.filter_aiding_measurement_summary_data_rate_,
+        }
+      ) : 1
     }
   );  // NOLINT(whitespace/parens)  No way to get around this
   timer_update_rate_hz_ = std::min(2 * max_rate, 1000);

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -321,17 +321,14 @@ void MicrostrainParser::parseIMUPacket(const mscl::MipDataPacket& packet)
   }
 
   // Publish
-  if (has_accel || has_gyro || has_quat)
-    if (publishers_->imu_pub_ != nullptr)
-      publishers_->imu_pub_->publish(publishers_->imu_msg_);
+  if (publishers_->imu_pub_ != nullptr && (has_accel || has_gyro || has_quat))
+    publishers_->imu_pub_->publish(publishers_->imu_msg_);
 
-  if (has_mag)
-    if (publishers_->mag_pub_ != nullptr)
-      publishers_->mag_pub_->publish(publishers_->mag_msg_);
+  if (publishers_->mag_pub_ != nullptr && has_mag)
+    publishers_->mag_pub_->publish(publishers_->mag_msg_);
 
-  if (publishers_->gps_corr_pub_ != nullptr)
-    if (publishers_->gps_corr_pub_ != nullptr)
-      publishers_->gps_corr_pub_->publish(publishers_->gps_corr_msg_);
+  if (publishers_->gps_corr_pub_ != nullptr && has_gps_corr)
+    publishers_->gps_corr_pub_->publish(publishers_->gps_corr_msg_);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -979,48 +976,38 @@ void MicrostrainParser::parseFilterPacket(const mscl::MipDataPacket& packet)
             publishers_->filtered_imu_msg_.angular_velocity_covariance.begin());
 
   // Publish
-  if (filter_status_received)
-    if (publishers_->filter_status_pub_ != nullptr)
-      publishers_->filter_status_pub_->publish(publishers_->filter_status_msg_);
+  if (publishers_->filter_status_pub_ != nullptr && filter_status_received)
+    publishers_->filter_status_pub_->publish(publishers_->filter_status_msg_);
   
-  if (filter_heading_received)
-    if (publishers_->filter_heading_pub_ != nullptr)
-      publishers_->filter_heading_pub_->publish(publishers_->filter_heading_msg_);
+  if (publishers_->filter_heading_pub_ != nullptr && filter_heading_received)
+    publishers_->filter_heading_pub_->publish(publishers_->filter_heading_msg_);
 
-  if (filter_heading_state_received)
-    if (publishers_->filter_heading_state_pub_ != nullptr)
-      publishers_->filter_heading_state_pub_->publish(publishers_->filter_heading_state_msg_);
+  if (publishers_->filter_heading_state_pub_ != nullptr && filter_heading_state_received)
+    publishers_->filter_heading_state_pub_->publish(publishers_->filter_heading_state_msg_);
   
-  if (filter_odom_received)
-    if (publishers_->filter_pub_ != nullptr)
-      publishers_->filter_pub_->publish(publishers_->filter_msg_);
+  if (publishers_->filter_pub_ != nullptr && filter_odom_received)
+    publishers_->filter_pub_->publish(publishers_->filter_msg_);
 
-  if (filter_imu_received)
-    if (publishers_->filtered_imu_pub_ != nullptr)
-      publishers_->filtered_imu_pub_->publish(publishers_->filtered_imu_msg_);
+  if (publishers_->filtered_imu_pub_ != nullptr && filter_imu_received)
+    publishers_->filtered_imu_pub_->publish(publishers_->filtered_imu_msg_);
   
-  if (filter_relative_odom_received)
-    if (publishers_->filter_relative_pos_pub_ != nullptr)
-      publishers_->filter_relative_pos_pub_->publish(publishers_->filter_relative_pos_msg_);
+  if (publishers_->filter_relative_pos_pub_ != nullptr && filter_relative_odom_received)
+    publishers_->filter_relative_pos_pub_->publish(publishers_->filter_relative_pos_msg_);
   
-  if (relative_transform_received)
-    if (publishers_->transform_broadcaster_ != nullptr)
-      publishers_->transform_broadcaster_->sendTransform(publishers_->filter_transform_msg_);
+  if (publishers_->transform_broadcaster_ != nullptr && relative_transform_received)
+    publishers_->transform_broadcaster_->sendTransform(publishers_->filter_transform_msg_);
 
   for (int i = 0; i < NUM_GNSS; i++)
   {
-    if (gnss_aiding_status_received[i])
-      if (publishers_->gnss_aiding_status_pub_[i] != nullptr)
-        publishers_->gnss_aiding_status_pub_[i]->publish(publishers_->gnss_aiding_status_msg_[i]);
+    if (publishers_->gnss_aiding_status_pub_[i] != nullptr && gnss_aiding_status_received[i])
+      publishers_->gnss_aiding_status_pub_[i]->publish(publishers_->gnss_aiding_status_msg_[i]);
   }
 
-  if (gnss_dual_antenna_status_received)
-    if (publishers_->gnss_dual_antenna_status_pub_ != nullptr)
-      publishers_->gnss_dual_antenna_status_pub_->publish(publishers_->gnss_dual_antenna_status_msg_);
+  if (publishers_->gnss_dual_antenna_status_pub_ != nullptr && gnss_dual_antenna_status_received)
+    publishers_->gnss_dual_antenna_status_pub_->publish(publishers_->gnss_dual_antenna_status_msg_);
 
-  if (filter_aiding_measurement_summary_received)
-    if (publishers_->filter_aiding_measurement_summary_pub_ != nullptr)
-      publishers_->filter_aiding_measurement_summary_pub_->publish(publishers_->filter_aiding_measurement_summary_msg_);
+  if (publishers_->filter_aiding_measurement_summary_pub_ != nullptr && filter_aiding_measurement_summary_received)
+    publishers_->filter_aiding_measurement_summary_pub_->publish(publishers_->filter_aiding_measurement_summary_msg_);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1184,22 +1171,17 @@ void MicrostrainParser::parseGNSSPacket(const mscl::MipDataPacket& packet, int g
   }
 
   // Publish
-  if (has_nav_sat_fix)
-    if (publishers_->gnss_pub_[gnss_id] != nullptr)
-      publishers_->gnss_pub_[gnss_id]->publish(publishers_->gnss_msg_[gnss_id]);
+  if (publishers_->gnss_pub_[gnss_id] != nullptr && has_nav_sat_fix)
+    publishers_->gnss_pub_[gnss_id]->publish(publishers_->gnss_msg_[gnss_id]);
   
-  if (has_odom)
-    if (publishers_->gnss_odom_pub_[gnss_id] != nullptr)
-      publishers_->gnss_odom_pub_[gnss_id]->publish(publishers_->gnss_odom_msg_[gnss_id]);
+  if (publishers_->gnss_odom_pub_[gnss_id] != nullptr && has_odom)
+    publishers_->gnss_odom_pub_[gnss_id]->publish(publishers_->gnss_odom_msg_[gnss_id]);
 
-  if (time_valid)
-    if (publishers_->gnss_time_pub_[gnss_id] != nullptr)
-      publishers_->gnss_time_pub_[gnss_id]->publish(publishers_->gnss_time_msg_[gnss_id]);
+  if (publishers_->gnss_time_pub_[gnss_id] != nullptr && time_valid)
+    publishers_->gnss_time_pub_[gnss_id]->publish(publishers_->gnss_time_msg_[gnss_id]);
     
-  if (has_fix_info)
-    if (publishers_->gnss_fix_info_pub_[gnss_id] != nullptr)
-      publishers_->gnss_fix_info_pub_[gnss_id]->publish(publishers_->gnss_fix_info_msg_[gnss_id]);
-
+  if (publishers_->gnss_fix_info_pub_[gnss_id] != nullptr && has_fix_info)
+    publishers_->gnss_fix_info_pub_[gnss_id]->publish(publishers_->gnss_fix_info_msg_[gnss_id]);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/microstrain_publishers.cpp
+++ b/src/microstrain_publishers.cpp
@@ -29,9 +29,6 @@ bool MicrostrainPublishers::configure()
     device_status_pub_ = create_publisher<StatusMsg>(node_, "device/status", 100);
   }
 
-  // Create the transorm broadcaster
-  transform_broadcaster_ = create_transform_broadcaster(node_);
-
   if (config_->publish_imu_)
   {
     // Publish IMU data, if enabled
@@ -80,8 +77,9 @@ bool MicrostrainPublishers::configure()
       MICROSTRAIN_INFO(node_, "Publishing GNSS1 fix info data.");
       gnss_fix_info_pub_[GNSS1_ID] = create_publisher<GNSSFixInfoMsg>(node_, "gnss1/fix_info", 100);
     }
-    if (config_->publish_gnss_aiding_status_[GNSS1_ID])
+    if (config_->publish_filter_aiding_status_ && config_->filter_aiding_status_data_rate_ != 0)
     {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS1 aiding status");
       gnss_aiding_status_pub_[GNSS1_ID] = create_publisher<GNSSAidingStatusMsg>(node_, "gnss1/aiding_status", 100);
     }
   }
@@ -113,8 +111,9 @@ bool MicrostrainPublishers::configure()
       MICROSTRAIN_INFO(node_, "Publishing GNSS2 fix info data.");
       gnss_fix_info_pub_[GNSS2_ID] = create_publisher<GNSSFixInfoMsg>(node_, "gnss2/fix_info", 100);
     }
-    if (config_->publish_gnss_aiding_status_[GNSS2_ID])
+    if (config_->publish_filter_aiding_status_ && config_->filter_aiding_status_data_rate_ != 0)
     {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS2 aiding status");
       gnss_aiding_status_pub_[GNSS2_ID] = create_publisher<GNSSAidingStatusMsg>(node_, "gnss2/aiding_status", 100);
     }
   }
@@ -133,33 +132,64 @@ bool MicrostrainPublishers::configure()
       rtk_pub_v1_ = create_publisher<RTKStatusMsgV1>(node_, "rtk/status_v1", 100);
     }
   }
+  else
+  {
+    MICROSTRAIN_DEBUG(node_, "Not publushing RTK data because publish_rtk = %d and supports_rtk = %d", config_->publish_filter_, config_->supports_rtk_);
+  }
 
   // If the device has a kalman filter, publish relevant topics
   if (config_->publish_filter_ && config_->supports_filter_)
   {
-    MICROSTRAIN_INFO(node_, "Publishing Filter data.");
-    filter_pub_ = create_publisher<OdometryMsg>(node_, "nav/odom", 100);
-    filter_status_pub_ = create_publisher<FilterStatusMsg>(node_, "nav/status", 100);
-    filter_heading_pub_ = create_publisher<FilterHeadingMsg>(node_, "nav/heading", 100);
-    filter_heading_state_pub_ = create_publisher<FilterHeadingStateMsg>(node_, "nav/heading_state", 100);
-    filtered_imu_pub_ = create_publisher<ImuMsg>(node_, "nav/filtered_imu/data", 100);
-
-    if (config_->filter_enable_gnss_heading_aiding_)
+    if (config_->filter_status_data_rate_ != 0)
     {
+      MICROSTRAIN_INFO(node_, "Publishing Filter status data");
+      filter_status_pub_ = create_publisher<FilterStatusMsg>(node_, "nav/status", 100);
+    }
+    if (config_->filter_heading_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing Filter heading message");
+      filter_heading_pub_ = create_publisher<FilterHeadingMsg>(node_, "nav/heading", 100);
+    }
+    if (config_->filter_heading_state_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing Filter heading state message");
+      filter_heading_state_pub_ = create_publisher<FilterHeadingStateMsg>(node_, "nav/heading_state", 100);
+    }
+    if (config_->filter_odom_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing Filter odometry message");
+      filter_pub_ = create_publisher<OdometryMsg>(node_, "nav/odom", 100);
+    }
+    if (config_->filter_imu_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing Filtered IMU data");
+      filtered_imu_pub_ = create_publisher<ImuMsg>(node_, "nav/filtered_imu/data", 100);
+    }
+    if (config_->publish_filter_relative_pos_ && config_->filter_relative_odom_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing relative odometry message");
+      filter_relative_pos_pub_ = create_publisher<OdometryMsg>(node_, "nav/relative_pos/odom", 100);
+
+      // Create the transorm broadcaster
+      MICROSTRAIN_INFO(node_, "Publising transform from %s to %s", config_->filter_frame_id_.c_str(), config_->filter_child_frame_id_.c_str());
+      transform_broadcaster_ = create_transform_broadcaster(node_);
+    }
+    if (config_->filter_enable_gnss_heading_aiding_ && config_->filter_gnss_dual_antenna_status_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing Dual Antenna Status message");
       gnss_dual_antenna_status_pub_ =
           create_publisher<GNSSDualAntennaStatusMsg>(node_, "nav/dual_antenna_status", 100);
     }
-
-    if (config_->publish_filter_relative_pos_)
+    if (config_->publish_filter_aiding_measurement_summary_ && config_->filter_aiding_measurement_summary_data_rate_ != 0)
     {
-      filter_relative_pos_pub_ = create_publisher<OdometryMsg>(node_, "nav/relative_pos/odom", 100);
-    }
-
-    if (config_->publish_filter_aiding_measurement_summary_)
-    {
+      MICROSTRAIN_INFO(node_, "Publishing Aiding Summary message");
       filter_aiding_measurement_summary_pub_ =
           create_publisher<FilterAidingMeasurementSummaryMsg>(node_, "nav/aiding_summary", 100);
     }
+  }
+  else
+  {
+    MICROSTRAIN_DEBUG(node_, "Not publishing filter data because publish_filter = %d and supports_filter = %d", config_->publish_filter_, config_->supports_filter_);
   }
 
   // If the device supports RTK (has an aux port), and we were asked to, stream NMEA sentences

--- a/src/microstrain_publishers.cpp
+++ b/src/microstrain_publishers.cpp
@@ -60,31 +60,67 @@ bool MicrostrainPublishers::configure()
   // If the device has GNSS1, publish relevant topics
   if (config_->publish_gnss_[GNSS1_ID] && config_->supports_gnss1_)
   {
-    MICROSTRAIN_INFO(node_, "Publishing GNSS1 data.");
-    gnss_pub_[GNSS1_ID] = create_publisher<NavSatFixMsg>(node_, "gnss1/fix", 100);
-    gnss_odom_pub_[GNSS1_ID] = create_publisher<OdometryMsg>(node_, "gnss1/odom", 100);
-    gnss_time_pub_[GNSS1_ID] = create_publisher<TimeReferenceMsg>(node_, "gnss1/time_ref", 100);
-    gnss_fix_info_pub_[GNSS1_ID] = create_publisher<GNSSFixInfoMsg>(node_, "gnss1/fix_info", 100);
-
+    if (config_->gnss_nav_sat_fix_data_rate_[GNSS1_ID] != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS1 NavSatFix data.");
+      gnss_pub_[GNSS1_ID] = create_publisher<NavSatFixMsg>(node_, "gnss1/fix", 100);
+    }
+    if (config_->gnss_odom_data_rate_[GNSS1_ID] != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS1 odom data.");
+      gnss_odom_pub_[GNSS1_ID] = create_publisher<OdometryMsg>(node_, "gnss1/odom", 100);
+    }
+    if (config_->gnss_time_reference_data_rate_[GNSS1_ID] != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS1 time reference data.");
+      gnss_time_pub_[GNSS1_ID] = create_publisher<TimeReferenceMsg>(node_, "gnss1/time_ref", 100);
+    }
+    if (config_->gnss_fix_info_data_rate_[GNSS1_ID] != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS1 fix info data.");
+      gnss_fix_info_pub_[GNSS1_ID] = create_publisher<GNSSFixInfoMsg>(node_, "gnss1/fix_info", 100);
+    }
     if (config_->publish_gnss_aiding_status_[GNSS1_ID])
     {
       gnss_aiding_status_pub_[GNSS1_ID] = create_publisher<GNSSAidingStatusMsg>(node_, "gnss1/aiding_status", 100);
     }
   }
+  else
+  {
+    MICROSTRAIN_DEBUG(node_, "Not publishing GNSS1 data because publish_gnss1 = %d and supports_gnss1 = %d", config_->publish_gnss_[GNSS1_ID], config_->supports_gnss1_);
+  }
 
   // If the device has GNSS2, publish relevant topics
   if (config_->publish_gnss_[GNSS2_ID] && config_->supports_gnss2_)
   {
-    MICROSTRAIN_INFO(node_, "Publishing GNSS2 data.");
-    gnss_pub_[GNSS2_ID] = create_publisher<NavSatFixMsg>(node_, "gnss2/fix", 100);
-    gnss_odom_pub_[GNSS2_ID] = create_publisher<OdometryMsg>(node_, "gnss2/odom", 100);
-    gnss_time_pub_[GNSS2_ID] = create_publisher<TimeReferenceMsg>(node_, "gnss2/time_ref", 100);
-    gnss_fix_info_pub_[GNSS2_ID] = create_publisher<GNSSFixInfoMsg>(node_, "gnss2/fix_info", 100);
-
+    if (config_->gnss_nav_sat_fix_data_rate_[GNSS2_ID] != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS2 NavSatFix data.");
+      gnss_pub_[GNSS2_ID] = create_publisher<NavSatFixMsg>(node_, "gnss2/fix", 100);
+    }
+    if (config_->gnss_odom_data_rate_[GNSS2_ID] != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS2 odom data.");
+      gnss_odom_pub_[GNSS2_ID] = create_publisher<OdometryMsg>(node_, "gnss2/odom", 100);
+    }
+    if (config_->gnss_time_reference_data_rate_[GNSS2_ID] != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS2 time reference data.");
+      gnss_time_pub_[GNSS2_ID] = create_publisher<TimeReferenceMsg>(node_, "gnss2/time_ref", 100);
+    }
+    if (config_->gnss_fix_info_data_rate_[GNSS2_ID] != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing GNSS2 fix info data.");
+      gnss_fix_info_pub_[GNSS2_ID] = create_publisher<GNSSFixInfoMsg>(node_, "gnss2/fix_info", 100);
+    }
     if (config_->publish_gnss_aiding_status_[GNSS2_ID])
     {
       gnss_aiding_status_pub_[GNSS2_ID] = create_publisher<GNSSAidingStatusMsg>(node_, "gnss2/aiding_status", 100);
     }
+  }
+  else
+  {
+    MICROSTRAIN_DEBUG(node_, "Not publishing GNSS2 data because publish_gnss2 = %d and supports_gnss2 = %d", config_->publish_gnss_[GNSS2_ID], config_->supports_gnss2_);
   }
 
   // If the device has RTK, publish relevant topics

--- a/src/microstrain_publishers.cpp
+++ b/src/microstrain_publishers.cpp
@@ -32,26 +32,29 @@ bool MicrostrainPublishers::configure()
   // Create the transorm broadcaster
   transform_broadcaster_ = create_transform_broadcaster(node_);
 
-  // Publish IMU data, if enabled
   if (config_->publish_imu_)
   {
-    MICROSTRAIN_INFO(node_, "Publishing IMU data.");
-    imu_pub_ = create_publisher<ImuMsg>(node_, "imu/data", 100);
-  }
+    // Publish IMU data, if enabled
+    if (config_->imu_raw_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing raw IMU data.");
+      imu_pub_ = create_publisher<ImuMsg>(node_, "imu/data", 100);
+    }
 
-  // Publish IMU GPS correlation data, if enabled
-  if (config_->publish_imu_ && config_->publish_gps_corr_)
-  {
-    MICROSTRAIN_INFO(node_, "Publishing IMU GPS correlation timestamp.");
-    gps_corr_pub_ = create_publisher<GPSCorrelationTimestampStampedMsg>(node_, "gps_corr", 100);
-  }
+    // If the device has a magnetometer, publish relevant topics
+    if (config_->inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_MAG_HARD_IRON_OFFSET) &&
+        config_->imu_mag_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing Magnetometer data.");
+      mag_pub_ = create_publisher<MagneticFieldMsg>(node_, "mag", 100);
+    }
 
-  // If the device has a magnetometer, publish relevant topics
-  if (config_->publish_imu_ &&
-      config_->inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_MAG_HARD_IRON_OFFSET))
-  {
-    MICROSTRAIN_INFO(node_, "Publishing Magnetometer data.");
-    mag_pub_ = create_publisher<MagneticFieldMsg>(node_, "mag", 100);
+    // Publish IMU GPS correlation data, if enabled
+    if (config_->publish_gps_corr_ && config_->imu_gps_corr_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing IMU GPS correlation timestamp.");
+      gps_corr_pub_ = create_publisher<GPSCorrelationTimestampStampedMsg>(node_, "gps_corr", 100);
+    }
   }
 
   // If the device has GNSS1, publish relevant topics

--- a/src/microstrain_publishers.cpp
+++ b/src/microstrain_publishers.cpp
@@ -126,9 +126,12 @@ bool MicrostrainPublishers::configure()
   // If the device has RTK, publish relevant topics
   if (config_->publish_rtk_ && config_->supports_rtk_)
   {
-    MICROSTRAIN_INFO(node_, "Publishing RTK data.");
-    rtk_pub_ = create_publisher<RTKStatusMsg>(node_, "rtk/status", 100);
-    rtk_pub_v1_ = create_publisher<RTKStatusMsgV1>(node_, "rtk/status_v1", 100);
+    if (config_->rtk_status_data_rate_ != 0)
+    {
+      MICROSTRAIN_INFO(node_, "Publishing RTK status data.");
+      rtk_pub_ = create_publisher<RTKStatusMsg>(node_, "rtk/status", 100);
+      rtk_pub_v1_ = create_publisher<RTKStatusMsgV1>(node_, "rtk/status_v1", 100);
+    }
   }
 
   // If the device has a kalman filter, publish relevant topics


### PR DESCRIPTION
* Adds the ability to control each ROS publishers data rate.
* Adds the ability to disable a published ROS message and the associated MIP fields by setting the data rate to `0`
* Adds the ability to use the old rates (`imu_data_rate`, `gnss1_data_rate`, `gnss2_data_rate`, `filter_data_rate`) by setting the more granular data rates to `-1`
* Changes the main loop to only publish messages when they are actually received instead of publishing all messages in a descriptor set when any one is received.

The following parameters have been added to allow the user to control the associated topics. Additional documentation on how to configure these data rates and other caveats can be found in the [params.yml](https://github.com/LORD-MicroStrain/microstrain_inertial_driver_common/blob/feature/different_data_rates/config/params.yml):
| Parameter | Topic(s) |
| -------------- | ------- |
| `imu_raw_data_rate` | `imu/data` |
| `imu_mag_data_rate` | `mag` |
| `imu_gps_corr_data_rate` | `gps_corr` |
| `gnss1_nav_sat_fix_data_rate` | `gnss1/fix` |
| `gnss1_odom_data_rate` | `gnss1/odom` |
| `gnss1_time_reference_data_rate` | `gnss1/time_ref` |
| `gnss1_fix_info_data_rate` | `gnss1/fix_info` |
| `gnss2_nav_sat_fix_data_rate` | `gnss2/fix` |
| `gnss2_odom_data_rate` | `gnss2/odom` |
| `gnss2_time_reference_data_rate` | `gnss2/time_ref` |
| `gnss2_fix_info_data_rate` | `gnss2/fix_info` |
| `rtk_status_data_rate` | `rtk/status`, `rtk/status_v1` |
| `filter_status_data_rate` | `nav/status` |
| `filter_heading_data_rate` | `nav/heading` |
| `filter_heading_state_data_rate` | `nav/heading_state` |
| `filter_odom_data_rate` | `nav/odom` |
| `filter_imu_data_rate` | `nav/filtered_imu/data` |
| `filter_relative_odom_data_rate` | `nav/relative_pos/odom`, `/tf` |
| `filter_aiding_status_data_rate` | `gnss1/aiding_status`, `gnss2/aiding_status` |
| `filter_gnss_dual_antenna_data_rate` | `nav/dual_antenna_status` |
| `filter_aiding_measurement_summary_data_rate` | `nav/aiding_summary` |