### PR TITLE
fix roslint errors except for whitespace/line_length, runtime/references, and readability/fn_size

### DIFF
--- a/include/microstrain_inertial_driver_common/microstrain_parser.h
+++ b/include/microstrain_inertial_driver_common/microstrain_parser.h
@@ -11,6 +11,7 @@
 #ifndef MICROSTRAIN_INERTIAL_DRIVER_COMMON_MICROSTRAIN_PARSER_H
 #define MICROSTRAIN_INERTIAL_DRIVER_COMMON_MICROSTRAIN_PARSER_H
 
+#include <string>
 #include "microstrain_inertial_driver_common/microstrain_defs.h"
 #include "microstrain_inertial_driver_common/microstrain_ros_funcs.h"
 #include "microstrain_inertial_driver_common/microstrain_config.h"

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -238,7 +238,6 @@ bool MicrostrainConfig::connectDevice(RosNodeType* node)
       aux_connection_ = std::unique_ptr<mscl::Connection>(new mscl::Connection(mscl::Connection::Serial(realpath(aux_port.c_str(), 0), (uint32_t)baudrate)));
       aux_connection_->rawByteMode(true);
     }
-
   }
   catch (mscl::Error_Connection& e)
   {
@@ -958,7 +957,7 @@ bool MicrostrainConfig::configureFilter(RosNodeType* node)
     MICROSTRAIN_INFO(node_, "Note: The device does not support the next-gen filter initialization command.");
   }
 
-  // Configure the hardware odometer settings  
+  // Configure the hardware odometer settings
   if (inertial_device_->features().supportsCommand(mscl::MipTypes::Command::CMD_ODOMETER_SETTINGS))
   {
     mscl::OdometerConfiguration odom_config;

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -14,6 +14,7 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 #include <algorithm>
+#include <string>
 #include "microstrain_inertial_driver_common/microstrain_parser.h"
 
 namespace microstrain
@@ -518,7 +519,7 @@ void MicrostrainParser::parseFilterPacket(const mscl::MipDataPacket& packet)
 
         if (config_->use_enu_frame_)
         {
-          tf2::Quaternion q_body2enu, q_ned2enu, q_vehiclebody2sensorbody, 
+          tf2::Quaternion q_body2enu, q_ned2enu, q_vehiclebody2sensorbody,
                           qbody2ned(quaternion.as_floatAt(1), quaternion.as_floatAt(2),
                                     quaternion.as_floatAt(3), quaternion.as_floatAt(0));
 
@@ -559,7 +560,7 @@ void MicrostrainParser::parseFilterPacket(const mscl::MipDataPacket& packet)
         {
           curr_filter_angular_rate_y_ = point.as_float();
 
-          if(config_->use_enu_frame_)
+          if (config_->use_enu_frame_)
             curr_filter_angular_rate_y_ *= -1.0;
 
           publishers_->filter_msg_.twist.twist.angular.y = curr_filter_angular_rate_y_;
@@ -570,7 +571,7 @@ void MicrostrainParser::parseFilterPacket(const mscl::MipDataPacket& packet)
         {
           curr_filter_angular_rate_z_ = point.as_float();
 
-          if(config_->use_enu_frame_)
+          if (config_->use_enu_frame_)
             curr_filter_angular_rate_z_ *= -1.0;
 
           publishers_->filter_msg_.twist.twist.angular.z = curr_filter_angular_rate_z_;
@@ -593,7 +594,7 @@ void MicrostrainParser::parseFilterPacket(const mscl::MipDataPacket& packet)
         {
           float accel_y = point.as_float();
 
-          if(config_->use_enu_frame_)
+          if (config_->use_enu_frame_)
             accel_y *= -1.0;
 
           publishers_->filtered_imu_msg_.linear_acceleration.y = accel_y;
@@ -602,7 +603,7 @@ void MicrostrainParser::parseFilterPacket(const mscl::MipDataPacket& packet)
         {
           float accel_z = point.as_float();
 
-          if(config_->use_enu_frame_)
+          if (config_->use_enu_frame_)
             accel_z *= -1.0;
 
           publishers_->filtered_imu_msg_.linear_acceleration.z = accel_z;


### PR DESCRIPTION
Could go and fix the other issues also but it will result in a much larger diff.

Paired with [862e7a8bb9cc20f19258c4890542967e757aa770](https://github.com/lucasw/microstrain_inertial/commit/862e7a8bb9cc20f19258c4890542967e757aa770) to make the above roslint exceptions (would have to correct that commit to point back at this repository instead of my fork).

Alternatively make the parent repo `microstrain_inertial` not run roslint on any of these files.
