### PR TITLE
NMEA Parser Bugfix

### DIFF
--- a/include/microstrain_inertial_driver_common/microstrain_parser.h
+++ b/include/microstrain_inertial_driver_common/microstrain_parser.h
@@ -19,6 +19,9 @@
 namespace microstrain
 {
 
+static constexpr auto NMEA_START_SEQUENCE = "$";
+static constexpr auto NMEA_STOP_SEQUENCE = "\r\n";
+
 /**
  * Contains parsing code that will parse messages read from the device and publish them
  */

--- a/include/microstrain_inertial_driver_common/microstrain_parser.h
+++ b/include/microstrain_inertial_driver_common/microstrain_parser.h
@@ -19,7 +19,7 @@
 namespace microstrain
 {
 
-static constexpr auto NMEA_START_SEQUENCE = "$";
+static constexpr auto NMEA_START_SEQUENCE = "$GPGGA,";
 static constexpr auto NMEA_STOP_SEQUENCE = "\r\n";
 
 /**

--- a/include/microstrain_inertial_driver_common/microstrain_parser.h
+++ b/include/microstrain_inertial_driver_common/microstrain_parser.h
@@ -19,6 +19,7 @@
 namespace microstrain
 {
 
+static constexpr auto NMEA_MAX_LENGTH = 82;
 static constexpr auto NMEA_START_SEQUENCE = "$GPGGA,";
 static constexpr auto NMEA_STOP_SEQUENCE = "\r\n";
 
@@ -144,6 +145,8 @@ private:
   float curr_filter_att_uncert_roll_;
   float curr_filter_att_uncert_pitch_;
   float curr_filter_att_uncert_yaw_;
+
+  std::string aux_string_;
 };  // struct MicrostrainParser
 
 }  // namespace microstrain

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -123,7 +123,7 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     if (publishers_->nmea_sentence_pub_ != nullptr)
       publishers_->nmea_sentence_pub_->publish(publishers_->nmea_sentence_msg_);
 
-    // Remove the sentence from the string
+    // Remove everything from the beginning of the string to the end of the NMEA sentence as it should all be parsed now
     aux_string_.erase(0, nmea_end_index + 1);
     search_index = 0;
   }

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -70,46 +70,53 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
   while (search_index < aux_string.size())
   {
     // If we can't find a $, there are no more NMEA sentences, so exit early
-    const size_t nmea_start_index = aux_string.find('$', search_index);
+    const size_t nmea_start_index = aux_string.find(NMEA_START_SEQUENCE, search_index);
     if (nmea_start_index == std::string::npos)
     {
+      MICROSTRAIN_DEBUG(node_, "Unable to find Start of NMEA sentence (%s) in string, skipping", NMEA_START_SEQUENCE);
       break;
     }
+    MICROSTRAIN_DEBUG(node_, "Found beginning of NMEA packet at %lu", nmea_start_index);
 
     // Make sure that what follows the dollar sign is a string that is 5 characters long and a comma
     const size_t first_comma_index = aux_string.find(',', nmea_start_index + 1);
     if (first_comma_index == std::string::npos || first_comma_index - nmea_start_index > 6)
     {
       // This is either an invalid NMEA message, or a MIP packet, either way skip it
+      MICROSTRAIN_DEBUG(node_, "Found start of NMEA packet, but the %s was not followed by 5 characters and a comma, skipping", NMEA_START_SEQUENCE);
       search_index++;
       continue;
     }
 
     // Search for the end of the NMEA string
-    const size_t nmea_end_index = aux_string.find("\r\n", nmea_start_index + 1) + 1;
+    const size_t nmea_end_index = aux_string.find(NMEA_STOP_SEQUENCE, first_comma_index + 1);
     if (nmea_end_index == std::string::npos)
     {
       MICROSTRAIN_WARN(node_, "Malformed NMEA sentence received. Ignoring sentence");
       break;
     }
+    MICROSTRAIN_DEBUG(node_, "Found end of NMEA packet at %lu", nmea_end_index);
 
     // If there is another $ between the first $ and the end string, the first $ might have been part of a MIP message, so start over at the second $
-    const size_t possible_mid_index = aux_string.find('$', nmea_start_index + 1);
+    const size_t possible_mid_index = aux_string.find(NMEA_START_SEQUENCE, nmea_start_index + 1);
     if (possible_mid_index != std::string::npos && possible_mid_index < nmea_end_index)
     {
+      MICROSTRAIN_DEBUG(node_, "Found another %s within what we thought was a NMEA packet, likely the first %s was part of a MIP packet, starting over from second %s", NMEA_START_SEQUENCE, NMEA_START_SEQUENCE, NMEA_START_SEQUENCE);
       search_index = possible_mid_index;
       continue;
     }
 
     // Get the NMEA substring, and update the index for the next iteration
-    const std::string& nmea_sentence = aux_string.substr(nmea_start_index, (nmea_end_index - nmea_start_index) + 1);
-    search_index = nmea_end_index + 1;
+    const std::string& nmea_sentence = aux_string.substr(nmea_start_index, (nmea_end_index - nmea_start_index) + strlen(NMEA_STOP_SEQUENCE));
+    search_index = nmea_end_index + strlen(NMEA_STOP_SEQUENCE);
+    MICROSTRAIN_DEBUG(node_, "Found NMEA sentence %s", nmea_sentence.c_str());
 
     // Publish the NMEA sentence to ROS
     publishers_->nmea_sentence_msg_.header.stamp = ros_time_now(node_);
     publishers_->nmea_sentence_msg_.header.frame_id = config_->nmea_frame_id_;
     publishers_->nmea_sentence_msg_.sentence = nmea_sentence;
-    publishers_->nmea_sentence_pub_->publish(publishers_->nmea_sentence_msg_);
+    if (publishers_->nmea_sentence_pub_ != nullptr)
+      publishers_->nmea_sentence_pub_->publish(publishers_->nmea_sentence_msg_);
   }
 }
 

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -83,7 +83,7 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     }
     MICROSTRAIN_DEBUG(node_, "Found beginning of NMEA packet at %lu", nmea_start_index);
 
-    // Make sure that what follows the dollar sign is a string that is 5 characters long and a comma
+    // Make sure that what follows the dollar sign is a string that is at least 5 characters long and a comma
     const size_t first_comma_index = aux_string_.find(',', nmea_start_index + 1);
     if (first_comma_index == std::string::npos || first_comma_index - nmea_start_index > 6)
     {
@@ -112,8 +112,8 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     }
 
     // Get the NMEA substring, and update the index for the next iteration
-    const std::string& nmea_sentence = aux_string_.substr(nmea_start_index, (nmea_end_index - nmea_start_index) + strlen(NMEA_STOP_SEQUENCE));
-    search_index = nmea_end_index + strlen(NMEA_STOP_SEQUENCE);
+    const size_t nmea_sentence_len = (nmea_end_index - nmea_start_index) + strlen(NMEA_STOP_SEQUENCE);
+    const std::string& nmea_sentence = aux_string_.substr(nmea_start_index, nmea_sentence_len);
     MICROSTRAIN_DEBUG(node_, "Found NMEA sentence %s", nmea_sentence.c_str());
 
     // Publish the NMEA sentence to ROS
@@ -125,6 +125,7 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
 
     // Remove the sentence from the string
     aux_string_.erase(0, nmea_end_index + 1);
+    search_index = 0;
   }
 
   // If the string is longer than the max NMEA sentence size, trim it down

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -83,12 +83,12 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     }
     MICROSTRAIN_DEBUG(node_, "Found beginning of NMEA packet at %lu", nmea_start_index);
 
-    // Make sure that what follows the dollar sign is a string that is at least 5 characters long and a comma
+    // Make sure that there is a comma somewhere after the start index
     const size_t first_comma_index = aux_string_.find(',', nmea_start_index + 1);
-    if (first_comma_index == std::string::npos || first_comma_index - nmea_start_index > 6)
+    if (first_comma_index == std::string::npos)
     {
       // This is either an invalid NMEA message, or a MIP packet, either way skip it
-      MICROSTRAIN_DEBUG(node_, "Found start of NMEA packet, but the %s was not followed by 5 characters and a comma, skipping", NMEA_START_SEQUENCE);
+      MICROSTRAIN_DEBUG(node_, "Found start of NMEA packet, but the %s was not followed by a comma, skipping", NMEA_START_SEQUENCE);
       search_index++;
       continue;
     }

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -77,6 +77,8 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     if (nmea_start_index == std::string::npos)
     {
       MICROSTRAIN_DEBUG(node_, "Unable to find Start of NMEA sentence (%s) in string, skipping", NMEA_START_SEQUENCE);
+      if(aux_string_.find("\x75\x65", search_index) != std::string::npos)
+        MICROSTRAIN_DEBUG(node_, "This is probably a MIP packet");
       break;
     }
     MICROSTRAIN_DEBUG(node_, "Found beginning of NMEA packet at %lu", nmea_start_index);

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -65,12 +65,15 @@ void MicrostrainParser::parseMIPPacket(const mscl::MipDataPacket& packet)
 
 void MicrostrainParser::parseAuxString(const std::string& aux_string)
 {
+  // Append the string to our cached string
+  aux_string_ += aux_string;
+
   // Each string may have more than one NMEA message
   size_t search_index = 0;
-  while (search_index < aux_string.size())
+  while (search_index < aux_string_.size())
   {
     // If we can't find a $, there are no more NMEA sentences, so exit early
-    const size_t nmea_start_index = aux_string.find(NMEA_START_SEQUENCE, search_index);
+    const size_t nmea_start_index = aux_string_.find(NMEA_START_SEQUENCE, search_index);
     if (nmea_start_index == std::string::npos)
     {
       MICROSTRAIN_DEBUG(node_, "Unable to find Start of NMEA sentence (%s) in string, skipping", NMEA_START_SEQUENCE);
@@ -79,7 +82,7 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     MICROSTRAIN_DEBUG(node_, "Found beginning of NMEA packet at %lu", nmea_start_index);
 
     // Make sure that what follows the dollar sign is a string that is 5 characters long and a comma
-    const size_t first_comma_index = aux_string.find(',', nmea_start_index + 1);
+    const size_t first_comma_index = aux_string_.find(',', nmea_start_index + 1);
     if (first_comma_index == std::string::npos || first_comma_index - nmea_start_index > 6)
     {
       // This is either an invalid NMEA message, or a MIP packet, either way skip it
@@ -89,7 +92,7 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     }
 
     // Search for the end of the NMEA string
-    const size_t nmea_end_index = aux_string.find(NMEA_STOP_SEQUENCE, first_comma_index + 1);
+    const size_t nmea_end_index = aux_string_.find(NMEA_STOP_SEQUENCE, first_comma_index + 1);
     if (nmea_end_index == std::string::npos)
     {
       MICROSTRAIN_WARN(node_, "Malformed NMEA sentence received. Ignoring sentence");
@@ -98,7 +101,7 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     MICROSTRAIN_DEBUG(node_, "Found end of NMEA packet at %lu", nmea_end_index);
 
     // If there is another $ between the first $ and the end string, the first $ might have been part of a MIP message, so start over at the second $
-    const size_t possible_mid_index = aux_string.find(NMEA_START_SEQUENCE, nmea_start_index + 1);
+    const size_t possible_mid_index = aux_string_.find(NMEA_START_SEQUENCE, nmea_start_index + 1);
     if (possible_mid_index != std::string::npos && possible_mid_index < nmea_end_index)
     {
       MICROSTRAIN_DEBUG(node_, "Found another %s within what we thought was a NMEA packet, likely the first %s was part of a MIP packet, starting over from second %s", NMEA_START_SEQUENCE, NMEA_START_SEQUENCE, NMEA_START_SEQUENCE);
@@ -107,7 +110,7 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     }
 
     // Get the NMEA substring, and update the index for the next iteration
-    const std::string& nmea_sentence = aux_string.substr(nmea_start_index, (nmea_end_index - nmea_start_index) + strlen(NMEA_STOP_SEQUENCE));
+    const std::string& nmea_sentence = aux_string_.substr(nmea_start_index, (nmea_end_index - nmea_start_index) + strlen(NMEA_STOP_SEQUENCE));
     search_index = nmea_end_index + strlen(NMEA_STOP_SEQUENCE);
     MICROSTRAIN_DEBUG(node_, "Found NMEA sentence %s", nmea_sentence.c_str());
 
@@ -117,7 +120,14 @@ void MicrostrainParser::parseAuxString(const std::string& aux_string)
     publishers_->nmea_sentence_msg_.sentence = nmea_sentence;
     if (publishers_->nmea_sentence_pub_ != nullptr)
       publishers_->nmea_sentence_pub_->publish(publishers_->nmea_sentence_msg_);
+
+    // Remove the sentence from the string
+    aux_string_.erase(0, nmea_end_index + 1);
   }
+
+  // If the string is longer than the max NMEA sentence size, trim it down
+  if (aux_string_.size() > NMEA_MAX_LENGTH)
+    aux_string_.erase(0, (aux_string_.size() - NMEA_MAX_LENGTH) - 1);
 }
 
 RosTimeType MicrostrainParser::getPacketTimestamp(const mscl::MipDataPacket& packet) const


### PR DESCRIPTION
* Appends data to a buffer instead of assuming that each packet will have at least one NMEA sentence
* Properly checks for the end of a NMEA string instead of appending 1 to the length which overflows the `size_t` causing the check for an invalid packet to fail
* Constrains checks to only look for GGA messages to reduce likelihood of a MIP message messing up parsing