### PR TITLE
Check device pointer against nullptr

### DIFF
--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -1382,7 +1382,7 @@ void MicrostrainParser::parseRTKPacket(const mscl::MipDataPacket& packet)
 
 void MicrostrainParser::printPacketStats()
 {
-  if (config_->inertial_device_)
+  if (config_->inertial_device_ == nullptr)
   {
     return;
   }


### PR DESCRIPTION
I think this was the opposite of what was intended, found via this warning (which is maybe only in newer C++/g++ versions)

```
/home/lucasw/catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_driver/microstrain_inertial_driver_common/src/microstrain_parser.cpp:1374:42: warning: ‘this’ pointer is null [-Wnonnull]
```

