### PR TITLE
Serial Port Improvements

### DIFF
--- a/config/params.yml
+++ b/config/params.yml
@@ -92,14 +92,14 @@ raw_file_directory : "/home/your_name"
 # ****************************************************************** 
 
 publish_imu   : True
-imu_data_rate : 100
+imu_data_rate : 100.0
 
 # The speed at which the individual IMU publishers will publish at.
 #      If set to -1, will use imu_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
-imu_raw_data_rate      : -1  # Rate of imu/data topic
-imu_mag_data_rate      : -1  # Rate of mag topic
-imu_gps_corr_data_rate : -1  # Rate of gps_corr topic
+imu_raw_data_rate      : -1.0  # Rate of imu/data topic
+imu_mag_data_rate      : -1.0  # Rate of mag topic
+imu_gps_corr_data_rate : -1.0  # Rate of gps_corr topic
                              # Note that this is still dependent on publish_gps_corr being set to True in order to publish
 
 # Static IMU message covariance values (the device does not generate these) 
@@ -117,7 +117,7 @@ publish_gps_corr : False
 # GNSS Settings (only applicable for devices with GNSS) 
 # ****************************************************************** 
 publish_gnss1   : True
-gnss1_data_rate : 2
+gnss1_data_rate : 2.0
 
 # The speed at which the individual GNSS1 publishers will publish at.
 #      If set to -1, will use gnss1_data_rate to determine the rate at which to stream and publish
@@ -125,10 +125,10 @@ gnss1_data_rate : 2
 #
 #      Note: The parameters' "gnss1_nav_sat_fix_data_rate", "gnss1_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-gnss1_nav_sat_fix_data_rate    : -1  # Rate of gnss1/fix topic
-gnss1_odom_data_rate           : -1  # Rate of gnss1/odom topic
-gnss1_time_reference_data_rate : -1  # Rate of gnss1/time_ref topic
-gnss1_fix_info_data_rate       : -1  # Rate of gnss1/fix_info topic
+gnss1_nav_sat_fix_data_rate    : -1.0  # Rate of gnss1/fix topic
+gnss1_odom_data_rate           : -1.0  # Rate of gnss1/odom topic
+gnss1_time_reference_data_rate : -1.0  # Rate of gnss1/time_ref topic
+gnss1_fix_info_data_rate       : -1.0  # Rate of gnss1/fix_info topic
 
 # Antenna #1 lever arm offset vector
 #     For GQ7 - in the vehicle frame wrt IMU origin (meters)
@@ -138,7 +138,7 @@ gnss1_antenna_offset : [0.0, -0.7, -1.0]
 
 # GNSS2 settings are only applicable for multi-GNSS systems (e.g. GQ7) 
 publish_gnss2   : True
-gnss2_data_rate : 2
+gnss2_data_rate : 2.0
 
 # The speed at which the individual GNSS2 publishers will publish at.
 #      If set to -1, will use gnss2_data_rate to determine the rate at which to stream and publish
@@ -146,10 +146,10 @@ gnss2_data_rate : 2
 #
 #      Note: The parameters' "gnss2_nav_sat_fix_data_rate", "gnss2_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-gnss2_nav_sat_fix_data_rate    : -1  # Rate of gnss2/fix topic
-gnss2_odom_data_rate           : -1  # Rate of gnss2/odom topic
-gnss2_time_reference_data_rate : -1  # Rate of gnss2/time_ref topic
-gnss2_fix_info_data_rate       : -1  # Rate of gnss2/fix_info topic
+gnss2_nav_sat_fix_data_rate    : -1.0  # Rate of gnss2/fix topic
+gnss2_odom_data_rate           : -1.0  # Rate of gnss2/odom topic
+gnss2_time_reference_data_rate : -1.0  # Rate of gnss2/time_ref topic
+gnss2_fix_info_data_rate       : -1.0  # Rate of gnss2/fix_info topic
 
 # Antenna #2 lever arm offset vector (In the vehicle frame wrt IMU origin (meters) )
 # Note: Make this as accurate as possible for good performance 
@@ -163,7 +163,7 @@ rtk_dongle_enable : False
 # The speed at which the individual RTK publishers will publish at.
 #      If set to -1, will publish at 1 hz which was the default before allowing users to configure this rate
 #      If set to 0, the stream will be turned off and the publisher will not be created
-rtk_status_data_rate : -1  # Rate of rtk/status or rtk/status_v1 topics
+rtk_status_data_rate : -1.0  # Rate of rtk/status or rtk/status_v1 topics
                            # Note that this is still reliant on rtk_dongle_enable being set to true to publish
 
 # (GQ7 Only) Allow the user to send RTCM messages to this node, and stream those messages to the GQ7
@@ -178,7 +178,7 @@ publish_nmea   : False
 # ****************************************************************** 
 
 publish_filter   : True
-filter_data_rate : 10
+filter_data_rate : 10.0
 
 # The speed at which the individual Filter publishers will publish at.
 #      If set to -1, will use filter_data_rate to determine the rate at which to stream and publish
@@ -186,20 +186,20 @@ filter_data_rate : 10
 #
 #      Note: The parameters' "filter_odom_data_rate", "filter_imu_data_rate", "filter_relative_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-filter_status_data_rate                     : -1  # Rate of nav/status topic
-filter_heading_data_rate                    : -1  # Rate of nav/heading topic
-filter_heading_state_data_rate              : -1  # Rate of nav/heading_state topic
-filter_odom_data_rate                       : -1  # Rate of nav/odom topic
-filter_imu_data_rate                        : -1  # Rate of nav/filtered_imu/data
-filter_relative_odom_data_rate              : -1  # Rate of nav/relative_pos topic and the transform between filter_frame_id and filter_child_frame_id
-                                                  # Note that this is still dependent on publish_relative_position being set to True in order to publish
-                                                  # Note that this data rate will also control the rate at which the transform between "filter_frame_id" and "filter_child_frame_id" will be published at
-filter_aiding_status_data_rate              : -1  # Rate of gnss1/aiding_status and gnss2/aiding_status topics
-                                                  # Note that this is still dependent on filter_enable_gnss_pos_vel_aiding being set to True in order to publish
-filter_gnss_dual_antenna_data_rate          : -1  # Rate of nav/dual_antenna_status topic
-                                                  # Note that this is still dependent on filter_enable_gnss_heading_aiding being set to True in order to publish
-filter_aiding_measurement_summary_data_rate : -1  # Rate of nav/aiding_summary topic
-                                                  # Note that this is still dependent on publish_filter_aiding_measurement_summary being set to True in order to publish
+filter_status_data_rate                     : -1.0  # Rate of nav/status topic
+filter_heading_data_rate                    : -1.0  # Rate of nav/heading topic
+filter_heading_state_data_rate              : -1.0  # Rate of nav/heading_state topic
+filter_odom_data_rate                       : -1.0  # Rate of nav/odom topic
+filter_imu_data_rate                        : -1.0  # Rate of nav/filtered_imu/data
+filter_relative_odom_data_rate              : -1.0  # Rate of nav/relative_pos topic and the transform between filter_frame_id and filter_child_frame_id
+                                                    # Note that this is still dependent on publish_relative_position being set to True in order to publish
+                                                    # Note that this data rate will also control the rate at which the transform between "filter_frame_id" and "filter_child_frame_id" will be published at
+filter_aiding_status_data_rate              : -1.0  # Rate of gnss1/aiding_status and gnss2/aiding_status topics
+                                                    # Note that this is still dependent on filter_enable_gnss_pos_vel_aiding being set to True in order to publish
+filter_gnss_dual_antenna_data_rate          : -1.0  # Rate of nav/dual_antenna_status topic
+                                                    # Note that this is still dependent on filter_enable_gnss_heading_aiding being set to True in order to publish
+filter_aiding_measurement_summary_data_rate : -1.0  # Rate of nav/aiding_summary topic
+                                                    # Note that this is still dependent on publish_filter_aiding_measurement_summary being set to True in order to publish
 
 # Sensor2vehicle frame transformation selector
 #     0 = None, 1 = Euler Angles, 2 - matrix, 3 - quaternion

--- a/config/params.yml
+++ b/config/params.yml
@@ -19,6 +19,9 @@ baudrate    : 115200
 debug       : False
 diagnostics : False
 
+# If set to true, this will configure the requested baudrate on the device. Note that this only has an affect when the device is connected via serial
+set_baud : True
+
 # Frame IDs used in the different messages. By default these are set to arbitrary strings as not to interfere with other ROS services.
 # For more information on common frame IDs, check out: https://www.ros.org/reps/rep-0105.html
 #

--- a/config/params.yml
+++ b/config/params.yml
@@ -95,14 +95,14 @@ raw_file_directory : "/home/your_name"
 # ****************************************************************** 
 
 publish_imu   : True
-imu_data_rate : 100.0
+imu_data_rate : 100
 
-# The speed at which the individual IMU publishers will publish at.
+# The speed at which the individual IMU publishers will publish at. Note that not all data rates are supported. A warning will be logged if you choose an unsupported data rate
 #      If set to -1, will use imu_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
-imu_raw_data_rate      : -1.0  # Rate of imu/data topic
-imu_mag_data_rate      : -1.0  # Rate of mag topic
-imu_gps_corr_data_rate : -1.0  # Rate of gps_corr topic
+imu_raw_data_rate      : -1  # Rate of imu/data topic
+imu_mag_data_rate      : -1  # Rate of mag topic
+imu_gps_corr_data_rate : -1  # Rate of gps_corr topic
                              # Note that this is still dependent on publish_gps_corr being set to True in order to publish
 
 # Static IMU message covariance values (the device does not generate these) 
@@ -120,18 +120,18 @@ publish_gps_corr : False
 # GNSS Settings (only applicable for devices with GNSS) 
 # ****************************************************************** 
 publish_gnss1   : True
-gnss1_data_rate : 2.0
+gnss1_data_rate : 2
 
-# The speed at which the individual GNSS1 publishers will publish at.
+# The speed at which the individual GNSS1 publishers will publish at. Note that not all data rates are supported. A warning will be logged if you choose an unsupported data rate
 #      If set to -1, will use gnss1_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
 #
 #      Note: The parameters' "gnss1_nav_sat_fix_data_rate", "gnss1_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-gnss1_nav_sat_fix_data_rate    : -1.0  # Rate of gnss1/fix topic
-gnss1_odom_data_rate           : -1.0  # Rate of gnss1/odom topic
-gnss1_time_reference_data_rate : -1.0  # Rate of gnss1/time_ref topic
-gnss1_fix_info_data_rate       : -1.0  # Rate of gnss1/fix_info topic
+gnss1_nav_sat_fix_data_rate    : -1  # Rate of gnss1/fix topic
+gnss1_odom_data_rate           : -1  # Rate of gnss1/odom topic
+gnss1_time_reference_data_rate : -1  # Rate of gnss1/time_ref topic
+gnss1_fix_info_data_rate       : -1  # Rate of gnss1/fix_info topic
 
 # Antenna #1 lever arm offset vector
 #     For GQ7 - in the vehicle frame wrt IMU origin (meters)
@@ -141,18 +141,18 @@ gnss1_antenna_offset : [0.0, -0.7, -1.0]
 
 # GNSS2 settings are only applicable for multi-GNSS systems (e.g. GQ7) 
 publish_gnss2   : True
-gnss2_data_rate : 2.0
+gnss2_data_rate : 2
 
-# The speed at which the individual GNSS2 publishers will publish at.
+# The speed at which the individual GNSS2 publishers will publish at. Note that not all data rates are supported. A warning will be logged if you choose an unsupported data rate
 #      If set to -1, will use gnss2_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
 #
 #      Note: The parameters' "gnss2_nav_sat_fix_data_rate", "gnss2_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-gnss2_nav_sat_fix_data_rate    : -1.0  # Rate of gnss2/fix topic
-gnss2_odom_data_rate           : -1.0  # Rate of gnss2/odom topic
-gnss2_time_reference_data_rate : -1.0  # Rate of gnss2/time_ref topic
-gnss2_fix_info_data_rate       : -1.0  # Rate of gnss2/fix_info topic
+gnss2_nav_sat_fix_data_rate    : -1  # Rate of gnss2/fix topic
+gnss2_odom_data_rate           : -1  # Rate of gnss2/odom topic
+gnss2_time_reference_data_rate : -1  # Rate of gnss2/time_ref topic
+gnss2_fix_info_data_rate       : -1  # Rate of gnss2/fix_info topic
 
 # Antenna #2 lever arm offset vector (In the vehicle frame wrt IMU origin (meters) )
 # Note: Make this as accurate as possible for good performance 
@@ -163,10 +163,10 @@ gnss2_antenna_offset : [0.0, 0.7, -1.0]
 #   on the version of the RTK dongle connected to the GQ7
 rtk_dongle_enable : False
 
-# The speed at which the individual RTK publishers will publish at.
+# The speed at which the individual RTK publishers will publish at. Note that not all data rates are supported. A warning will be logged if you choose an unsupported data rate
 #      If set to -1, will publish at 1 hz which was the default before allowing users to configure this rate
 #      If set to 0, the stream will be turned off and the publisher will not be created
-rtk_status_data_rate : -1.0  # Rate of rtk/status or rtk/status_v1 topics
+rtk_status_data_rate : -1  # Rate of rtk/status or rtk/status_v1 topics
                            # Note that this is still reliant on rtk_dongle_enable being set to true to publish
 
 # (GQ7 Only) Allow the user to send RTCM messages to this node, and stream those messages to the GQ7
@@ -181,28 +181,28 @@ publish_nmea   : False
 # ****************************************************************** 
 
 publish_filter   : True
-filter_data_rate : 10.0
+filter_data_rate : 10
 
-# The speed at which the individual Filter publishers will publish at.
+# The speed at which the individual Filter publishers will publish at. Note that not all data rates are supported. A warning will be logged if you choose an unsupported data rate
 #      If set to -1, will use filter_data_rate to determine the rate at which to stream and publish
 #      If set to 0, the stream will be turned off and the publisher will not be created
 #
 #      Note: The parameters' "filter_odom_data_rate", "filter_imu_data_rate", "filter_relative_odom_data_rate" associated ROS messages share several MIP fields,
 #            so if more than one is set to stream, and they are set to stream at different rates, messages will be published on both topics, at the higher rate
-filter_status_data_rate                     : -1.0  # Rate of nav/status topic
-filter_heading_data_rate                    : -1.0  # Rate of nav/heading topic
-filter_heading_state_data_rate              : -1.0  # Rate of nav/heading_state topic
-filter_odom_data_rate                       : -1.0  # Rate of nav/odom topic
-filter_imu_data_rate                        : -1.0  # Rate of nav/filtered_imu/data
-filter_relative_odom_data_rate              : -1.0  # Rate of nav/relative_pos topic and the transform between filter_frame_id and filter_child_frame_id
-                                                    # Note that this is still dependent on publish_relative_position being set to True in order to publish
-                                                    # Note that this data rate will also control the rate at which the transform between "filter_frame_id" and "filter_child_frame_id" will be published at
-filter_aiding_status_data_rate              : -1.0  # Rate of gnss1/aiding_status and gnss2/aiding_status topics
-                                                    # Note that this is still dependent on filter_enable_gnss_pos_vel_aiding being set to True in order to publish
-filter_gnss_dual_antenna_data_rate          : -1.0  # Rate of nav/dual_antenna_status topic
-                                                    # Note that this is still dependent on filter_enable_gnss_heading_aiding being set to True in order to publish
-filter_aiding_measurement_summary_data_rate : -1.0  # Rate of nav/aiding_summary topic
-                                                    # Note that this is still dependent on publish_filter_aiding_measurement_summary being set to True in order to publish
+filter_status_data_rate                     : -1  # Rate of nav/status topic
+filter_heading_data_rate                    : -1  # Rate of nav/heading topic
+filter_heading_state_data_rate              : -1  # Rate of nav/heading_state topic
+filter_odom_data_rate                       : -1  # Rate of nav/odom topic
+filter_imu_data_rate                        : -1  # Rate of nav/filtered_imu/data
+filter_relative_odom_data_rate              : -1  # Rate of nav/relative_pos topic and the transform between filter_frame_id and filter_child_frame_id
+                                                  # Note that this is still dependent on publish_relative_position being set to True in order to publish
+                                                  # Note that this data rate will also control the rate at which the transform between "filter_frame_id" and "filter_child_frame_id" will be published at
+filter_aiding_status_data_rate              : -1  # Rate of gnss1/aiding_status and gnss2/aiding_status topics
+                                                  # Note that this is still dependent on filter_enable_gnss_pos_vel_aiding being set to True in order to publish
+filter_gnss_dual_antenna_data_rate          : -1  # Rate of nav/dual_antenna_status topic
+                                                  # Note that this is still dependent on filter_enable_gnss_heading_aiding being set to True in order to publish
+filter_aiding_measurement_summary_data_rate : -1  # Rate of nav/aiding_summary topic
+                                                  # Note that this is still dependent on publish_filter_aiding_measurement_summary being set to True in order to publish
 
 # Sensor2vehicle frame transformation selector
 #     0 = None, 1 = Euler Angles, 2 - matrix, 3 - quaternion

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -30,7 +30,7 @@ const std::vector<double> DEFAULT_MATRIX = { 9.0, 0.0 };
 const std::vector<double> DEFAULT_VECTOR = { 3.0, 0.0 };
 const std::vector<double> DEFAULT_QUATERNION = { 4.0, 0.0 };
 
-static constexpr int DEFAULT_DATA_RATE = -1;  // If a data rate is set to this, the data rate will be set to the default data rate
+static constexpr float DEFAULT_DATA_RATE = -1;  // If a data rate is set to this, the data rate will be set to the default data rate
 
 /**
  * Contains configuration information for the node, configures the device on startup
@@ -146,9 +146,15 @@ public:
    */
   bool configureSensor2vehicle(RosNodeType* node);
 
+  // Generic config options
+  bool debug_;
+
   // Device pointer used to interact with the device
   std::unique_ptr<mscl::InertialNode> inertial_device_;
   std::unique_ptr<mscl::Connection> aux_connection_;
+
+  // Information used to connect to the device
+  int32_t baudrate_;
 
   // Config read from the device
   bool supports_gnss1_;
@@ -227,34 +233,34 @@ public:
   std::vector<double> imu_orientation_cov_;
 
   // Update rates
-  int imu_data_rate_;
-  int gnss_data_rate_[NUM_GNSS];
-  int filter_data_rate_;
+  float imu_data_rate_;
+  float gnss_data_rate_[NUM_GNSS];
+  float filter_data_rate_;
 
   // IMU update rates
-  int imu_raw_data_rate_;
-  int imu_mag_data_rate_;
-  int imu_gps_corr_data_rate_;
+  float imu_raw_data_rate_;
+  float imu_mag_data_rate_;
+  float imu_gps_corr_data_rate_;
 
   // GNSS update rates
-  int gnss_nav_sat_fix_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
-  int gnss_odom_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
-  int gnss_time_reference_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
-  int gnss_fix_info_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
+  float gnss_nav_sat_fix_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
+  float gnss_odom_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
+  float gnss_time_reference_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
+  float gnss_fix_info_data_rate_[NUM_GNSS] = { DEFAULT_DATA_RATE };
 
   // RTK update rates
-  int rtk_status_data_rate_ = DEFAULT_DATA_RATE;  // Note that this will be used for both the RTKv1 and RTKv2 status messages
+  float rtk_status_data_rate_ = DEFAULT_DATA_RATE;  // Note that this will be used for both the RTKv1 and RTKv2 status messages
 
   // Filter update rates
-  int filter_status_data_rate_ = DEFAULT_DATA_RATE;
-  int filter_heading_data_rate_ = DEFAULT_DATA_RATE;
-  int filter_heading_state_data_rate_ = DEFAULT_DATA_RATE;
-  int filter_odom_data_rate_ = DEFAULT_DATA_RATE;
-  int filter_imu_data_rate_ = DEFAULT_DATA_RATE;
-  int filter_relative_odom_data_rate_ = DEFAULT_DATA_RATE;  // Note that this will be used for both the relative odometry message and the transform published on the /tf topic
-  int filter_aiding_status_data_rate_ = DEFAULT_DATA_RATE;
-  int filter_gnss_dual_antenna_status_data_rate_ = DEFAULT_DATA_RATE;
-  int filter_aiding_measurement_summary_data_rate_ = DEFAULT_DATA_RATE;
+  float filter_status_data_rate_ = DEFAULT_DATA_RATE;
+  float filter_heading_data_rate_ = DEFAULT_DATA_RATE;
+  float filter_heading_state_data_rate_ = DEFAULT_DATA_RATE;
+  float filter_odom_data_rate_ = DEFAULT_DATA_RATE;
+  float filter_imu_data_rate_ = DEFAULT_DATA_RATE;
+  float filter_relative_odom_data_rate_ = DEFAULT_DATA_RATE;  // Note that this will be used for both the relative odometry message and the transform published on the /tf topic
+  float filter_aiding_status_data_rate_ = DEFAULT_DATA_RATE;
+  float filter_gnss_dual_antenna_status_data_rate_ = DEFAULT_DATA_RATE;
+  float filter_aiding_measurement_summary_data_rate_ = DEFAULT_DATA_RATE;
 
   // Gnss antenna offsets
   std::vector<double> gnss_antenna_offset_[NUM_GNSS];
@@ -291,7 +297,7 @@ private:
    * \param data_rate  The data rate value to populate with the config parameter
    * \param default_data_rate  The value to set data_rate to if it is set to -1
    */
-  static void getDataRateParam(RosNodeType* node, const std::string& key, int& data_rate, int default_data_rate);
+  static void getDataRateParam(RosNodeType* node, const std::string& key, float& data_rate, float default_data_rate);
 
   /**
    * \brief Convenience function to populate a list of channels and their requested data rates based on whether the device supports them
@@ -300,7 +306,7 @@ private:
    * \param data_rate  The rate in hertz to stream the MIP data at
    * \param channels_to_stream  List of channels and their associated rate that will be populated with the proper channels and data rates
    */
-  void getSupportedMipChannels(mscl::MipTypes::DataClass data_class, const mscl::MipTypes::MipChannelFields& channel_fields, int data_rate, mscl::MipChannels* channels_to_stream);
+  void getSupportedMipChannels(mscl::MipTypes::DataClass data_class, const mscl::MipTypes::MipChannelFields& channel_fields, float data_rate, mscl::MipChannels* channels_to_stream);
 
   /**
    * \brief Enables or disables a filter aiding measurement

--- a/include/microstrain_inertial_driver_common/microstrain_config.h
+++ b/include/microstrain_inertial_driver_common/microstrain_config.h
@@ -291,6 +291,14 @@ public:
 
 private:
   /**
+   * \brief Forces the device to idle
+   * \param max_tries The number of times to try setting the device to idle
+   * \param interval Amount of time to wait between setting the device to idle
+   * \return true if the device is now idle, false if setting to idle failed
+   */
+  bool forceIdle(const uint8_t max_tries = 3, const float interval = 2);
+
+  /**
    * \brief Gets the raw value of a data rate parameter, or populates the parameter with the default data rate if it is set to the default value
    * \param node  The ROS node that contains configuration information. For ROS1 this is the private node handle ("~")
    * \param key  The key to look for in the config for the data rate param

--- a/include/microstrain_inertial_driver_common/microstrain_defs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_defs.h
@@ -158,7 +158,7 @@ constexpr auto NUM_GNSS = 2;
 #include "nmea_msgs/msg/sentence.hpp"
 
 // .h header was deprecated in rolling and will likely be removed in future releases.
-#if MICROSTRAIN_ROLLING == 1
+#if MICROSTRAIN_ROLLING == 1 || MICROSTRAIN_HUMBLE == 1
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #else
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"

--- a/include/microstrain_inertial_driver_common/microstrain_node_base.h
+++ b/include/microstrain_inertial_driver_common/microstrain_node_base.h
@@ -42,6 +42,11 @@ public:
    */
   void parseAndPublishAux();
 
+  /**
+   * \brief If debug is enabled, this will be run every second to print debug information about the device
+   */
+  void logDeviceDebugInfo();
+
 protected:
   /**
    * \brief Default constructor
@@ -89,7 +94,11 @@ protected:
 
   RosTimerType main_parsing_timer_;
   RosTimerType aux_parsing_timer_;
+  RosTimerType log_debug_timer_;
   RosTimerType device_status_timer_;
+
+  size_t bytes_read_ = 0;  /// Number of bytes read this second
+  size_t bytes_written_ = 0;  /// Number of bytes written this second
 };  // MicrostrainNodeBase class
 
 }  // namespace microstrain

--- a/include/microstrain_inertial_driver_common/microstrain_ros_funcs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_ros_funcs.h
@@ -343,7 +343,7 @@ inline void stop_timer(RosTimerType timer)
  */
 inline void get_param_float(RosNodeType* node, const std::string& param_name, float& param_val, const float default_val)
 {
-  // Seems like ROS should be able to figure this out, but for ROS2 at least, floats need to be explicitly 
+  // Seems like ROS should be able to figure this out, but for ROS2 at least, we need to cast ints to floats so people don't have to put decimal points
   try
   {
     get_param<float>(node, param_name, param_val, default_val);

--- a/include/microstrain_inertial_driver_common/microstrain_ros_funcs.h
+++ b/include/microstrain_inertial_driver_common/microstrain_ros_funcs.h
@@ -334,6 +334,28 @@ inline void stop_timer(RosTimerType timer)
 #error "Unsupported ROS version. -DMICROSTRAIN_ROS_VERSION must be set to 1 or 2"
 #endif
 
+/**
+ * \brief Extention of get_param. Explicitly gets float parameter, even if it was specified as an int
+ * \param node  The ROS node to extract the config from
+ * \param param_name  The name of the config value to extract
+ * \param param_val  Variable to store the extracted config value in
+ * \param default_val  The default value to set param_val to if the config can't be found
+ */
+inline void get_param_float(RosNodeType* node, const std::string& param_name, float& param_val, const float default_val)
+{
+  // Seems like ROS should be able to figure this out, but for ROS2 at least, floats need to be explicitly 
+  try
+  {
+    get_param<float>(node, param_name, param_val, default_val);
+  }
+  catch (const std::exception& e)
+  {
+    int32_t param_val_int;
+    get_param<int32_t>(node, param_name, param_val_int, static_cast<int32_t>(default_val));
+    param_val = static_cast<float>(param_val_int);
+  }
+}
+
 }  // namespace microstrain
 
 #endif  // MICROSTRAIN_INERTIAL_DRIVER_COMMON_MICROSTRAIN_ROS_FUNCS_H

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -182,11 +182,13 @@ bool MicrostrainConfig::connectDevice(RosNodeType* node)
 {
   // Read the config required for only this section
   std::string port;
+  bool set_baud;
   std::string aux_port;
   bool poll_port;
   double poll_rate_hz;
   int32_t poll_max_tries;
   get_param<std::string>(node, "port", port, "/dev/ttyACM0");
+  get_param<bool>(node, "set_baud", set_baud, false);
   get_param<std::string>(node, "aux_port", aux_port, "/dev/ttyACM1");
   get_param<int32_t>(node, "baudrate", baudrate_, 115200);
   get_param<bool>(node, "poll_port", poll_port, false);
@@ -233,26 +235,28 @@ bool MicrostrainConfig::connectDevice(RosNodeType* node)
     mscl::Connection connection = mscl::Connection::Serial(realpath(port.c_str(), 0), (uint32_t)baudrate_);
     inertial_device_ = std::unique_ptr<mscl::InertialNode>(new mscl::InertialNode(connection));
 
-    // At this point, we have connected to the device but if it is streaming.
-    // Reading information may fail. Retry a few times to accomodate
-    int32_t set_to_idle_tries = 0;
-    while (set_to_idle_tries++ < 3)
+    // At this point, we have connected to the device but if it is streaming, reading information may fail. Retry setting to idle to accomodate
+    bool idle_success = forceIdle();
+
+    // If the device is not idle, we may have the wrong baudrate, so figure out the right one, configure it, and then switch back
+    if (!idle_success && set_baud)
     {
-      try
+      for (const uint32_t baud : {115200, 9600, 19200, 230400, 460800, 921600})
       {
-        // Put into idle mode
-        MICROSTRAIN_INFO(node_, "Setting to Idle: Stopping data streams and/or waking from sleep");
-        inertial_device_->setToIdle();
-        break;  // If setting to idle succeeded, we don't need to loop anymore as the device can now communicate
-      }
-      catch (const mscl::Error_Communication& e)
-      {
-        MICROSTRAIN_WARN(node_,
-            "It looks like the device is streaming. Waiting a second before setting to idle again");
-        RosRateType rate(1.0);
-        rate.sleep();
+        MICROSTRAIN_INFO(node_, "Attempting to open port at %d baud", baud);
+        inertial_device_->connection().updateBaudRate(baud);
+        if ((idle_success = forceIdle()) == true)
+        {
+          MICROSTRAIN_INFO(node_, "Device was previously configured at %d baud, changing to %d baud", baud, baudrate_);
+          inertial_device_->setUARTBaudRate(baudrate_);
+          break;
+        }
       }
     }
+
+    // If at this point, the device is still not idle, return an error
+    if (!idle_success)
+      return false;
 
     // Print the device info
     MICROSTRAIN_INFO(node_, R"(
@@ -378,6 +382,12 @@ bool MicrostrainConfig::setupDevice(RosNodeType* node)
     else
     {
       MICROSTRAIN_ERROR(node_, "**The device does not support the factory streaming channels setup command!");
+    }
+
+    // Warn users with a low baudrate
+    if (baudrate_ < 460800)
+    {
+      MICROSTRAIN_WARN(node_, "WARNING: The configured baudrate is too low to stream factory support channels over serial. If the device is connected via USB, this warning can be ignored.");
     }
   }
 
@@ -1270,6 +1280,28 @@ bool MicrostrainConfig::configureSensor2vehicle(RosNodeType* node)
     }
   }
   return true;
+}
+
+bool MicrostrainConfig::forceIdle(const uint8_t max_tries, const float interval)
+{
+  int32_t tries = 0;
+  while (tries++ < max_tries)
+  {
+    try
+    {
+      // Put into idle mode
+      MICROSTRAIN_INFO(node_, "Setting to Idle: Stopping data streams and/or waking from sleep");
+      inertial_device_->setToIdle();
+      return true;  // If setting to idle succeeded, we don't need to loop anymore as the device can now communicate
+    }
+    catch (const mscl::Error_Communication& e)
+    {
+      MICROSTRAIN_WARN(node_, "Unable to communicate with device. Waiting a second before setting to idle again, as the device may just be streaming");
+      RosRateType rate(interval);
+      rate.sleep();
+    }
+  }
+  return false;
 }
 
 void MicrostrainConfig::getDataRateParam(RosNodeType* node, const std::string& key, float& data_rate, float default_data_rate)

--- a/src/microstrain_config.cpp
+++ b/src/microstrain_config.cpp
@@ -171,7 +171,7 @@ bool MicrostrainConfig::configure(RosNodeType* node)
 
   if (!setupRawFile(node))
     return false;
-  
+
   if (debug_)
     inertial_device_->connection().debugMode(true);
 

--- a/src/microstrain_node_base.cpp
+++ b/src/microstrain_node_base.cpp
@@ -55,7 +55,7 @@ void MicrostrainNodeBase::parseAndPublishAux()
 
 void MicrostrainNodeBase::logDeviceDebugInfo()
 {
-  const size_t baudrate_max = (config_.baudrate_ / 9);
+  const size_t baudrate_max = (config_.baudrate_ / 10);
   const size_t total_bytes = bytes_read_ + bytes_written_;
   MICROSTRAIN_DEBUG(node_, "Device debug info");
   MICROSTRAIN_DEBUG(node_, "  total bytes   = %lu", total_bytes);

--- a/src/microstrain_parser.cpp
+++ b/src/microstrain_parser.cpp
@@ -1006,7 +1006,7 @@ void MicrostrainParser::parseFilterPacket(const mscl::MipDataPacket& packet)
             publishers_->filtered_imu_msg_.angular_velocity_covariance.begin());
 
   // Optionally transform the velocity into the vehicle frame
-  if (config_->filter_vel_in_vehicle_frame_)
+  if (config_->filter_vel_in_vehicle_frame_ && curr_filter_quaternion_.size() == 4)
   {
     const tf2::Vector3 tf_curr_vel = tf2::Vector3(curr_filter_vel_north_, curr_filter_vel_east_, curr_filter_vel_down_);
     const tf2::Quaternion quaternion(


### PR DESCRIPTION
* Adds logging loop every second that will print the number of bytes read and written
* Adds ability to configure the baudrate on the device using `set_baud`
* Changes `*_data_rate` fields to floating point numbers to allow users to configure data rates at non whole numbers
* Fixes bug where a quaternion would be indexed into before it was populated