### PR TITLE
fixed bug when computing nanoseconds for setRosTime

### DIFF
--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -955,7 +955,7 @@ void Publishers::updateHeaderTime(RosHeaderType* header, uint8_t descriptor_set,
   }
   else
   {
-    setRosTime(&header->stamp, timestamp / 1000, (timestamp % 1000) * 1000);
+    setRosTime(&header->stamp, timestamp / 1000, (timestamp % 1000) * 1000000);
   }
 }
 
@@ -967,7 +967,7 @@ void Publishers::setGpsTime(RosTimeType* time, const mip::data_shared::GpsTimest
 
   // Seconds since start of Unix time = seconds between 1970 and 1980 + number of weeks since 1980 * number of seconds in a week + number of complete seconds past in current week - leap seconds since start of GPS time
   const uint64_t utc_milliseconds = static_cast<uint64_t>((315964800 + timestamp.week_number * 604800 + static_cast<uint64_t>(seconds) - 18) * 1000L) + static_cast<uint64_t>(std::round(subseconds * 1000.0));
-  setRosTime(time, utc_milliseconds / 1000, (utc_milliseconds % 1000) * 1000);
+  setRosTime(time, utc_milliseconds / 1000, (utc_milliseconds % 1000) * 1000000);
 }
 
 }  // namespace microstrain


### PR DESCRIPTION
this small changes fixes a timestamping bug in the microstrain driver. We found it when investigating data recorded using the driver that the nanosecond timestamp is of by a factor of 1000. 