### PR TITLE
Preventative Bugfix for Float Literal Arrays in params.yml

### DIFF
--- a/config/params.yml
+++ b/config/params.yml
@@ -107,9 +107,9 @@ imu_overrange_status_data_rate : -1  # Rate of imu/overrange_status topic
 
 # Static IMU message covariance values (the device does not generate these) 
 # Since internally these are std::vector we need to use the rosparam tags 
-imu_orientation_cov : [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]
-imu_linear_cov      : [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]
-imu_angular_cov     : [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]
+imu_orientation_cov : [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+imu_linear_cov      : [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+imu_angular_cov     : [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
 
 # ****************************************************************** 
 # GNSS Settings (only applicable for devices with GNSS) 
@@ -383,7 +383,7 @@ filter_init_attitude : [0.0, 0.0, 0.0]
 filter_relative_position_config : False
 filter_relative_position_frame  : 2
 filter_relative_position_source : 1
-filter_relative_position_ref    : [0, 0, 0.01]
+filter_relative_position_ref    : [0.0, 0.0, 0.01]
 
 # (GQ7 only) Speed Lever Arm Configuration
 #   Lever Arm - In vehicle reference frame (meters)


### PR DESCRIPTION
My team recently ran into a compatibility issue between the microstrain ROS driver and another ROS library (namely 'foxglove_bridge', a backend ROS app that helps visualize the data on ROS topics) which was causing a crash in our visualization software.  This issue was eventually traced back to the parser used by Foxglove running into a problem reading our custom Microstrain params.yml file, since it naively assumed that all elements of a YAML list were the same kind of numeric literal and would fail if integers and floats were mixed inside of a list. 

This is primarily a problem with the parser for an entirely separate library, but I just wanted to contribute the work-around we used (namely, making sure all instances of floating-point numbers in lists that contain at least one float are formatted so that they cannot be interpreted as integers) so that other people who base their own custom 'params.yml' off of the original 'params.yml' in the future don't run into the same compatibility issues with other libraries that we encountered.