### PR TITLE
Fix: Only publish transforms to /tf if supported device

### DIFF
--- a/include/microstrain_inertial_driver_common/publishers.h
+++ b/include/microstrain_inertial_driver_common/publishers.h
@@ -253,6 +253,7 @@ public:
 
   // Published transforms
   TransformStampedMsg filter_relative_transform_msg_;
+  bool filter_relative_odom_supported_;
 
 private:
   /**

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -53,7 +53,14 @@ bool Publishers::configure()
 
   // Only publish relative odom if we support the relative position descriptor set
   if (config_->mip_device_->supportsDescriptor(mip::data_filter::DESCRIPTOR_SET, mip::data_filter::RelPosNed::FIELD_DESCRIPTOR))
+  {
     filter_relative_odom_pub_->configure(node_, config_);
+    filter_relative_odom_supported_ = true;
+  }
+  else
+  {
+    filter_relative_odom_supported_ = false;
+  }
 
   if (config_->publish_nmea_)
     nmea_sentence_pub_->configure(node_);
@@ -215,7 +222,7 @@ bool Publishers::deactivate()
 void Publishers::publish()
 {
   // If the corresponding messages were updated, publish the transforms
-  if (filter_relative_odom_pub_ && filter_relative_odom_pub_->updated())
+  if (filter_relative_odom_supported_ && filter_relative_odom_pub_ && filter_relative_odom_pub_->updated())
     transform_broadcaster_->sendTransform(filter_relative_transform_msg_);
 
   imu_pub_->publish();


### PR DESCRIPTION
- Currently the driver will publish transforms to /tf regardless of whether the 'filter relative odom' publisher is actually enabled / supported (dictated by whether device publishes the DATA_REL_POS_NED MIP msg).
- This fix will ensure that transforms are only published to /tf when the proper MIPs msg is being provided by the device
- Note: This does not address the repeat timestamping [issue](https://github.com/LORD-MicroStrain/microstrain_inertial_driver_common/issues/42) for devices which do support this msg