### PR TITLE
Uses `rtcm_msgs/Message` instead of `mavros_msgs/RTCM`

### DIFF
--- a/include/microstrain_inertial_driver_common/utils/mappings/mip_publisher_mapping.h
+++ b/include/microstrain_inertial_driver_common/utils/mappings/mip_publisher_mapping.h
@@ -62,7 +62,7 @@ static constexpr auto FILTER_RELATIVE_ODOM_TOPIC = "nav/relative_pos/odom";
 static constexpr auto FILTER_DUAL_ANTENNA_STATUS_TOPIC = "nav/dual_antenna_status";
 static constexpr auto FILTER_AIDING_SUMMARY_TOPIC = "nav/aiding_summary";
 
-static constexpr auto NMEA_SENTENCE_TOPIC = "nmea/sentence";
+static constexpr auto NMEA_SENTENCE_TOPIC = "nmea";
 
 // Some other constants
 static constexpr float FIELD_DATA_RATE_USE_DATA_CLASS = -1;

--- a/include/microstrain_inertial_driver_common/utils/ros_compat.h
+++ b/include/microstrain_inertial_driver_common/utils/ros_compat.h
@@ -62,7 +62,7 @@ constexpr auto NUM_GNSS = 2;
 #include "std_msgs/Bool.h"
 #include "std_msgs/String.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
-#include "mavros_msgs/RTCM.h"
+#include "rtcm_msgs/Message.h"
 #include "nmea_msgs/Sentence.h"
 
 #include "microstrain_inertial_msgs/Status.h"
@@ -166,7 +166,7 @@ constexpr auto NUM_GNSS = 2;
 #include "std_srvs/srv/trigger.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "std_msgs/msg/string.hpp"
-#include "mavros_msgs/msg/rtcm.hpp"
+#include "rtcm_msgs/msg/message.hpp"
 #include "nmea_msgs/msg/sentence.hpp"
 
 // .h header was deprecated in rolling and will likely be removed in future releases.
@@ -328,7 +328,7 @@ using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster
 using BoolMsg = ::std_msgs::Bool;
 using TimeReferenceMsg = ::sensor_msgs::TimeReference;
 using InputSpeedMeasurementMsg = ::microstrain_inertial_msgs::InputSpeedMeasurement;
-using RTCMMsg = ::mavros_msgs::RTCM;
+using RTCMMsg = ::rtcm_msgs::Message;
 
 // ROS1 Subscriber Types
 using BoolSubType = RosSubType;

--- a/include/microstrain_inertial_driver_common/utils/ros_compat.h
+++ b/include/microstrain_inertial_driver_common/utils/ros_compat.h
@@ -644,7 +644,7 @@ using TransformBroadcasterType = std::shared_ptr<::tf2_ros::TransformBroadcaster
 using BoolMsg = ::std_msgs::msg::Bool;
 using TimeReferenceMsg = ::sensor_msgs::msg::TimeReference;
 using InputSpeedMeasurementMsg = ::microstrain_inertial_msgs::msg::InputSpeedMeasurement;
-using RTCMMsg = ::mavros_msgs::msg::RTCM;
+using RTCMMsg = ::rtcm_msgs::msg::Message;
 
 // ROS2 Subscriber Types
 using BoolSubType = ::rclcpp::Subscription<BoolMsg>::SharedPtr;

--- a/src/subscribers.cpp
+++ b/src/subscribers.cpp
@@ -185,13 +185,13 @@ void Subscribers::externalSpeedCallback(const InputSpeedMeasurementMsg& speed)
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 void Subscribers::rtcmCallback(const RTCMMsg& rtcm)
 {
-  MICROSTRAIN_DEBUG(node_, "Received RTCM message of size %lu", rtcm.data.size());
+  MICROSTRAIN_DEBUG(node_, "Received RTCM message of size %lu", rtcm.message.size());
   if (config_->aux_device_)
   {
-    if (!config_->aux_device_->send(rtcm.data.data(), rtcm.data.size()))
+    if (!config_->aux_device_->send(rtcm.message.data(), rtcm.message.size()))
       MICROSTRAIN_ERROR(node_, "Failed to write RTCM to device");
     else
-      MICROSTRAIN_DEBUG(node_, "Successfully wrote RTCM message of size %lu to aux port", rtcm.data.size());
+      MICROSTRAIN_DEBUG(node_, "Successfully wrote RTCM message of size %lu to aux port", rtcm.message.size());
   }
   else
   {


### PR DESCRIPTION
* Also defaults nmea topic to just `nmea` instead of `nmea/sentence` for easier integration with the `ntrip_client` node