### PR TITLE
Fix 'error: redefinition of default argument' seen building in Ubuntu 23.04

### DIFF
--- a/include/microstrain_inertial_driver_common/services.h
+++ b/include/microstrain_inertial_driver_common/services.h
@@ -260,7 +260,7 @@ typename RosServiceType<ServiceType>::SharedPtr Services::configureService(const
   return createService<ServiceType>(node_, name, callback, this);
 }
 
-template<typename ServiceType, typename MipType, uint8_t DescriptorSet = MipType::DESCRIPTOR_SET>
+template<typename ServiceType, typename MipType, uint8_t DescriptorSet>
 typename RosServiceType<ServiceType>::SharedPtr Services::configureService(const std::string& name, bool (Services::*callback)(typename ServiceType::Request&, typename ServiceType::Response&))
 {
   if (config_->mip_device_->supportsDescriptor(DescriptorSet, MipType::FIELD_DESCRIPTOR))


### PR DESCRIPTION
When using https://github.com/LORD-MicroStrain/microstrain_inertial/commit/28bf364b9ff75baf0213dfb583dd150a02d988e8 (as mentioned in https://github.com/LORD-MicroStrain/microstrain_inertial/pull/157) I can get the build to finish along with this change (but haven't tried connecting to a real device).

```
In file included from /home/lucasw/catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_driver/microstrain_inertial_driver_common/include/microstrain_inertial_driver_common/node_common.h:25:
/home/lucasw/catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_driver/microstrain_inertial_driver_common/include/microstrain_inertial_driver_common/services.h:263:83: error: redefinition of default argument for ‘unsigned char DescriptorSet’
  263 | template<typename ServiceType, typename MipType, uint8_t DescriptorSet = MipType::DESCRIPTOR_SET>
      |                                                                                   ^~~~~~~~~~~~~~
/home/lucasw/catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_driver/microstrain_inertial_driver_common/include/microstrain_inertial_driver_common/services.h:186:85: note: original definition appeared here
  186 |   template<typename ServiceType, typename MipType, uint8_t DescriptorSet = MipType::DESCRIPTOR_SET>
      |        
```

There are a lot of these warnings, but only warnings:

```
/home/lucasw/catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_driver/microstrain_inertial_driver_common/include/microstrain_inertial_driver_common/services.h:276:1: warning: control reaches end of non-void function [-Wreturn-type]
```