### PR TITLE
Set covariance for filtered IMU message.

### DIFF
--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -178,6 +178,13 @@ bool Publishers::configure()
   std::copy(config_->imu_mag_cov_.begin(), config_->imu_mag_cov_.end(), mag_msg->magnetic_field_covariance.begin());
   pressure_pub_->getMessage()->variance = config_->imu_pressure_vairance_;
 
+  // Update filtered IMU covariance values
+  auto filter_imu_msg = filter_imu_pub_->getMessage();
+  std::copy(config_->imu_linear_cov_.begin(), config_->imu_linear_cov_.end(),
+            filter_imu_msg->linear_acceleration_covariance.begin());
+  std::copy(config_->imu_angular_cov_.begin(), config_->imu_angular_cov_.end(),
+            filter_imu_msg->angular_velocity_covariance.begin());
+
   supports_filter_ecef_ = config_->mip_device_->supportsDescriptor(mip::data_filter::DESCRIPTOR_SET, mip::data_filter::DATA_ECEF_POS);
 
   // Human readable status message configuration


### PR DESCRIPTION
In the current implementation, the IMU message published on ekf/imu/data sets the covariance for both angular_velocity and linear_acceleration to zero, which makes it difficult to use these fields without additional post-processing.

This PR updates the message to populate the covariance matrices using the existing parameters imu_linear_cov and imu_angular_cov.

<img width="1903" height="1001" alt="image" src="https://github.com/user-attachments/assets/f2e3c1be-9266-4387-a115-c27bd5680e31" />


I have one question regarding this change:
Does the internal filter provide any covariance estimation for these values? If so, I can integrate it directly. Otherwise, would it make sense to introduce dedicated parameters for these covariances?