### PR TITLE
Enable Conservative RTK mode for MicroStrain GQ7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/mip_sdk"]
 	path = mip_sdk
-	url = https://github.com/LORD-MicroStrain/mip_sdk.git
+	url = https://github.com/HBK-MicroStrain/mip_sdk.git

--- a/config/params.yml
+++ b/config/params.yml
@@ -187,7 +187,8 @@ rtk_dongle_enable : True
 ntrip_interface_enable : False
 
 # (GQ7 Only) RTK Configuration 
-# Note: this param will enable the "Conservative Ambiguity Resolution" fix mode for the GNSS receivers. 
+# Note: This is an experimental feature, available upon request in challenging GNSS/RTK conditions.
+# Enabling this param will enable the "Conservative Ambiguity Resolution" fix mode for the GNSS receivers. 
 # Enabling can help reduce the chance of achieving a false RTK integer fix, but may increase time-to-fix
 enable_conservative_rtk : False
 # ****************************************************************** 

--- a/config/params.yml
+++ b/config/params.yml
@@ -175,6 +175,10 @@ rtk_dongle_enable : True
 # Note: This will require the aux_port configuration to be valid and pointing to a valid aux port
 ntrip_interface_enable : False
 
+# (GQ7 Only) RTK Configuration 
+# Note: this param will enable the "Conservative Ambiguity Resolution" fix mode for the GNSS receivers. 
+# Enabling can help reduce the chance of achieving a false RTK integer fix, but may increase time-to-fix
+enable_conservative_rtk : False
 # ****************************************************************** 
 # Kalman Filter Settings (only applicable for devices with a Kalman Filter) 
 # ****************************************************************** 

--- a/include/microstrain_inertial_driver_common/services.h
+++ b/include/microstrain_inertial_driver_common/services.h
@@ -31,7 +31,6 @@ static constexpr auto MIP_3DM_DEVICE_SETTINGS_LOAD_SERVICE = "mip/three_dm/devic
 static constexpr auto MIP_3DM_GPIO_STATE_READ_SERVICE = "mip/three_dm/gpio_state/read";
 static constexpr auto MIP_3DM_GPIO_STATE_WRITE_SERVICE = "mip/three_dm/gpio_state/write";
 static constexpr auto MIP_FILTER_RESET_SERVICE = "mip/ekf/reset";
-static constexpr auto MIP_CONSERVATIVE_RTK_ENABLE_SERVICE = "mip/system/comm_mode";
 
 /**
  * Contains service functions and service handles
@@ -116,7 +115,6 @@ private:
   RosServiceType<Mip3dmGpioStateWriteSrv>::SharedPtr mip_3dm_gpio_state_write_service_;
 
   RosServiceType<EmptySrv>::SharedPtr mip_filter_reset_service_;
-  RosServiceType<EmptySrv>::SharedPtr mip_enable_conservative_rtk_service_;
 };
 
 template<typename ServiceType>

--- a/include/microstrain_inertial_driver_common/services.h
+++ b/include/microstrain_inertial_driver_common/services.h
@@ -72,7 +72,6 @@ public:
 
   bool mipFilterReset(EmptySrv::Request& req, EmptySrv::Response& res);
 
-  bool mipEnableConservativeRTKMode(EmptySrv::Request& req, EmptySrv::Response& res);
   
 private:
   /**

--- a/include/microstrain_inertial_driver_common/services.h
+++ b/include/microstrain_inertial_driver_common/services.h
@@ -31,6 +31,7 @@ static constexpr auto MIP_3DM_DEVICE_SETTINGS_LOAD_SERVICE = "mip/three_dm/devic
 static constexpr auto MIP_3DM_GPIO_STATE_READ_SERVICE = "mip/three_dm/gpio_state/read";
 static constexpr auto MIP_3DM_GPIO_STATE_WRITE_SERVICE = "mip/three_dm/gpio_state/write";
 static constexpr auto MIP_FILTER_RESET_SERVICE = "mip/ekf/reset";
+static constexpr auto MIP_CONSERVATIVE_RTK_ENABLE_SERVICE = "mip/system/comm_mode";
 
 /**
  * Contains service functions and service handles
@@ -115,6 +116,7 @@ private:
   RosServiceType<Mip3dmGpioStateWriteSrv>::SharedPtr mip_3dm_gpio_state_write_service_;
 
   RosServiceType<EmptySrv>::SharedPtr mip_filter_reset_service_;
+  RosServiceType<EmptySrv>::SharedPtr mip_enable_conservative_rtk_service_;
 };
 
 template<typename ServiceType>

--- a/include/microstrain_inertial_driver_common/services.h
+++ b/include/microstrain_inertial_driver_common/services.h
@@ -72,6 +72,8 @@ public:
 
   bool mipFilterReset(EmptySrv::Request& req, EmptySrv::Response& res);
 
+  bool mipEnableConservativeRTKMode(EmptySrv::Request& req, EmptySrv::Response& res);
+  
 private:
   /**
    * \brief Configures a non MIP command dependent service. This service will always be configured if this functions is called.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1360,55 +1360,18 @@ bool Config::configureSystem(RosNodeType* node)
   bool enable_conservative_rtk;
   getParam<bool>(node, "enable_conservative_rtk", enable_conservative_rtk, false); 
 
-  if (enable_conservative_rtk)
+  if (enable_conservative_rtk && mip_device_->supportsDescriptor(mip::commands_gnss::DESCRIPTOR_SET, mip::commands_gnss::CMD_CONFIGURATION))
   {
-    mip::CmdResult mip_cmd_result = mip::commands_system::writeCommMode(*mip_device_, 0x05);
-    if (!!mip_cmd_result)
-      MICROSTRAIN_DEBUG(node_, "Device in Direct mode to Receiver 1");
+    uint8_t reserved[4] = {0};
+    if (!(mip_cmd_result = mip::commands_gnss::writeRtkConfiguration(*mip_device_, mip::commands_gnss::RtkConfiguration::AmbiguityFixMode::CONSERVATIVE, reserved)))
+      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to configure RTK mode");
     else
-      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set receiver 1 to direct mode.");
-
-    sleep(1);
-    // Here, we need to send the raw configuration bytes to the receiver to enable CAR mode for the RTK algorithm.
-    // First, define the UBX configuration bytes in a buffer. These are the raw bytes requred to write the RTK-Conservative Ambiguity 
-    // Resolution mode to the receiver's Flash (change to RAM). 
-    uint8_t data[] = {0xB5, 0x62, 0x06, 0x8A, 0x09, 0x00, 0x00, 0x01, 0x00, 0x00, 0x11, 0x00, 0x14, 0x20, 0x05, 0xe4, 0x07 };
-    size_t size = 17;
-
-    if (mip_device_->send(data, size))
-      MICROSTRAIN_DEBUG(node_, "Receiver configuration bytes sent sucessfully.");
-    else 
-      MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
-    
-    // Sleep for 1 second to get the UBX bytes to send to the device correctly 
-    sleep(1); 
-
-    mip_cmd_result = mip::commands_system::writeCommMode(*mip_device_, 0x06);
-    if (!!mip_cmd_result)
-      MICROSTRAIN_DEBUG(node_, "Device in Direct mode to Receiver 2");
-    else
-      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set receiver 2 to direct mode.");
-
-    // Sleep for 1 second to get the UBX bytes to send to the device correctly 
-    sleep(1);
-
-    // Send the raw configuration bytest to receiver 2.
-    if (mip_device_->send(data, size))
-      MICROSTRAIN_DEBUG(node_, "Receiver configuration bytes sent sucessfully.");
-    else 
-      MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
-    // Sleep for 1 second to get the UBX bytes to send to the device correctly 
-    sleep(1);
-
-    mip_cmd_result = mip::commands_system::writeCommMode(*mip_device_, 0x01); //put the device back into normal mode
-    if (!!mip_cmd_result)
-      MICROSTRAIN_DEBUG(node_, "Device returned to Normal Mode.");
-    else
-      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set the receiver to normal mode. Power cycle device.");
-    
-    MICROSTRAIN_INFO(node_, "Conservative RTK mode enabled on Receiver 1 and Receiver 2");
+      MICROSTRAIN_DEBUG(node_, "RTK mode sucessfully set to Conservative")
   }
-
+  else
+  {
+    MICROSTRAIN_WARN(node_, "The RTK Configuration (0x0E, 0x04) Command is not supported on this device.");
+  }
   return true;
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1360,18 +1360,20 @@ bool Config::configureSystem(RosNodeType* node)
   bool enable_conservative_rtk;
   getParam<bool>(node, "enable_conservative_rtk", enable_conservative_rtk, false); 
 
-  if (enable_conservative_rtk && mip_device_->supportsDescriptor(mip::commands_gnss::DESCRIPTOR_SET, mip::commands_gnss::CMD_CONFIGURATION))
+  if (enable_conservative_rtk)
   {
-    uint8_t reserved[4] = {0};
-    if (!(mip_cmd_result = mip::commands_gnss::writeRtkConfiguration(*mip_device_, mip::commands_gnss::RtkConfiguration::AmbiguityFixMode::CONSERVATIVE, reserved)))
-      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to configure RTK mode");
+    if (mip_device_->supportsDescriptor(mip::commands_gnss::DESCRIPTOR_SET, mip::commands_gnss::CMD_CONFIGURATION))
+    {
+      uint8_t reserved[4] = {0};
+      if (!(mip_cmd_result = mip::commands_gnss::writeRtkConfiguration(*mip_device_, mip::commands_gnss::RtkConfiguration::AmbiguityFixMode::CONSERVATIVE, reserved)))
+        MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to configure RTK mode");
+      else
+        MICROSTRAIN_DEBUG(node_, "RTK mode successfully set to Conservative");
+    }
     else
-      MICROSTRAIN_DEBUG(node_, "RTK mode sucessfully set to Conservative")
+      MICROSTRAIN_WARN(node_, "The RTK Configuration Command is not available on this device");
   }
-  else
-  {
-    MICROSTRAIN_WARN(node_, "The RTK Configuration (0x0E, 0x04) Command is not supported on this device.");
-  }
+
   return true;
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1356,6 +1356,60 @@ bool Config::configureSystem(RosNodeType* node)
     rtcm_on_main_port_ = false;
   }
 
+  //Enable conservative RTK solution
+  bool enable_conservative_rtk;
+  getParam<bool>(node, "enable_conservative_rtk", enable_conservative_rtk, false); 
+
+  if (enable_conservative_rtk)
+  {
+    const mip::CmdResult mip_cmd_result = mip::commands_system::writeCommMode(*mip_device_, 0x05);
+    if (!!mip_cmd_result)
+      MICROSTRAIN_DEBUG(node_, "Device in Direct mode to Receiver 1");
+    else
+      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set receiver 1 to direct mode.");
+
+    sleep(1);
+    //Here, we need to send the raw configuration bytes to the receiver to enable CAR mode for the RTK algorithm.
+    //First, define the UBX configuration bytes in a buffer. These are the raw bytes requred to write the RTK-Conservative Ambiguity Resolution mode to the receiver's Flash (change to RAM). 
+    uint8_t data[] = {0xB5, 0x62, 0x06, 0x8A, 0x09, 0x00, 0x00, 0x01, 0x00, 0x00, 0x11, 0x00, 0x14, 0x20, 0x05, 0xe4, 0x07 };
+    size_t size = 17;
+
+    bool result = mip_device_->send(data, size);
+    
+    if (!!result)
+      MICROSTRAIN_DEBUG(node_, "Receiver configuration bytes sent sucessfully.");
+    else 
+      MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
+    sleep(1);
+
+    const mip::CmdResult mip_cmd_result_1 = mip::commands_system::writeCommMode(*mip_device_, 0x06);
+    if (!!mip_cmd_result_1)
+      MICROSTRAIN_DEBUG(node_, "Device in Direct mode to Receiver 2");
+    else
+      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result_1, "Failed to set receiver 2 to direct mode.");
+
+    sleep(1);
+    //Here, we need to send the raw configuration bytes to the receiver to enable CAR mode for the RTK algorithm.
+    //First, define the UBX configuration bytes in a buffer. These are the raw bytes requred to write the RTK-Conservative Ambiguity Resolution mode to the receiver's Flash (change to RAM). 
+
+    bool result_1 = mip_device_->send(data, size);
+
+    if (!!result_1)
+      MICROSTRAIN_DEBUG(node_, "Receiver configuration bytes sent sucessfully.");
+    else 
+      MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
+    sleep(1);
+    const mip::CmdResult mip_cmd_result_2 = mip::commands_system::writeCommMode(*mip_device_, 0x01); //put the device back into normal mode
+    if (!!mip_cmd_result_2)
+      MICROSTRAIN_DEBUG(node_, "Device returned to Normal Mode.");
+    else
+      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result_1, "Failed to set the receiver to normal mode. Power cycle device.");
+  
+      MICROSTRAIN_INFO(node_, "Conservative RTK mode enabled on Receiver 1 and Receiver 2");
+  }
+  
+
+
   return true;
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1356,59 +1356,58 @@ bool Config::configureSystem(RosNodeType* node)
     rtcm_on_main_port_ = false;
   }
 
-  //Enable conservative RTK solution
+  // Enable conservative RTK solution
   bool enable_conservative_rtk;
   getParam<bool>(node, "enable_conservative_rtk", enable_conservative_rtk, false); 
 
   if (enable_conservative_rtk)
   {
-    const mip::CmdResult mip_cmd_result = mip::commands_system::writeCommMode(*mip_device_, 0x05);
+    mip::CmdResult mip_cmd_result = mip::commands_system::writeCommMode(*mip_device_, 0x05);
     if (!!mip_cmd_result)
       MICROSTRAIN_DEBUG(node_, "Device in Direct mode to Receiver 1");
     else
       MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set receiver 1 to direct mode.");
 
     sleep(1);
-    //Here, we need to send the raw configuration bytes to the receiver to enable CAR mode for the RTK algorithm.
-    //First, define the UBX configuration bytes in a buffer. These are the raw bytes requred to write the RTK-Conservative Ambiguity Resolution mode to the receiver's Flash (change to RAM). 
+    // Here, we need to send the raw configuration bytes to the receiver to enable CAR mode for the RTK algorithm.
+    // First, define the UBX configuration bytes in a buffer. These are the raw bytes requred to write the RTK-Conservative Ambiguity 
+    // Resolution mode to the receiver's Flash (change to RAM). 
     uint8_t data[] = {0xB5, 0x62, 0x06, 0x8A, 0x09, 0x00, 0x00, 0x01, 0x00, 0x00, 0x11, 0x00, 0x14, 0x20, 0x05, 0xe4, 0x07 };
     size_t size = 17;
 
-    bool result = mip_device_->send(data, size);
-    
-    if (!!result)
+    if (mip_device_->send(data, size))
       MICROSTRAIN_DEBUG(node_, "Receiver configuration bytes sent sucessfully.");
     else 
       MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
-    sleep(1);
+    
+    // Sleep for 1 second to get the UBX bytes to send to the device correctly 
+    sleep(1); 
 
-    const mip::CmdResult mip_cmd_result_1 = mip::commands_system::writeCommMode(*mip_device_, 0x06);
-    if (!!mip_cmd_result_1)
+    mip_cmd_result = mip::commands_system::writeCommMode(*mip_device_, 0x06);
+    if (!!mip_cmd_result)
       MICROSTRAIN_DEBUG(node_, "Device in Direct mode to Receiver 2");
     else
-      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result_1, "Failed to set receiver 2 to direct mode.");
+      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set receiver 2 to direct mode.");
 
+    // Sleep for 1 second to get the UBX bytes to send to the device correctly 
     sleep(1);
-    //Here, we need to send the raw configuration bytes to the receiver to enable CAR mode for the RTK algorithm.
-    //First, define the UBX configuration bytes in a buffer. These are the raw bytes requred to write the RTK-Conservative Ambiguity Resolution mode to the receiver's Flash (change to RAM). 
 
-    bool result_1 = mip_device_->send(data, size);
-
-    if (!!result_1)
+    // Send the raw configuration bytest to receiver 2.
+    if (mip_device_->send(data, size))
       MICROSTRAIN_DEBUG(node_, "Receiver configuration bytes sent sucessfully.");
     else 
       MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
+    // Sleep for 1 second to get the UBX bytes to send to the device correctly 
     sleep(1);
-    const mip::CmdResult mip_cmd_result_2 = mip::commands_system::writeCommMode(*mip_device_, 0x01); //put the device back into normal mode
-    if (!!mip_cmd_result_2)
+
+    mip_cmd_result = mip::commands_system::writeCommMode(*mip_device_, 0x01); //put the device back into normal mode
+    if (!!mip_cmd_result)
       MICROSTRAIN_DEBUG(node_, "Device returned to Normal Mode.");
     else
-      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result_1, "Failed to set the receiver to normal mode. Power cycle device.");
-  
-      MICROSTRAIN_INFO(node_, "Conservative RTK mode enabled on Receiver 1 and Receiver 2");
+      MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set the receiver to normal mode. Power cycle device.");
+    
+    MICROSTRAIN_INFO(node_, "Conservative RTK mode enabled on Receiver 1 and Receiver 2");
   }
-  
-
 
   return true;
 }

--- a/src/node_common.cpp
+++ b/src/node_common.cpp
@@ -45,7 +45,7 @@ void logCallbackProxy(void* user, microstrain_log_level level, const char* fmt, 
 void NodeCommon::parseAndPublishMain()
 {
   // This should receive all packets, populate ROS messages and publish them as well
-  if (!config_.mip_device_->device().update())
+  if (!config_.mip_device_->device().update(10))
   {
     MICROSTRAIN_ERROR(node_, "Unable to update device");
 
@@ -110,7 +110,7 @@ void NodeCommon::parseAndPublishMain()
 void NodeCommon::parseAndPublishAux()
 {
   // This should receive all packets and populate NMEA messages
-  config_.aux_device_->device().update();
+  config_.aux_device_->device().update(10);
 
   // Publish the NMEA messages
   const auto connection = config_.aux_device_->connection();

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -30,7 +30,6 @@ bool Services::configure()
     raw_file_config_aux_read_service_ = createService<RawFileConfigReadSrv>(node_, RAW_FILE_CONFIG_AUX_READ_SERVICE, &Services::rawFileConfigAuxRead, this);
     raw_file_config_aux_write_service_ = createService<RawFileConfigWriteSrv>(node_, RAW_FILE_CONFIG_AUX_WRITE_SERVICE, &Services::rawFileConfigAuxWrite, this);
   }
-
   
 
   // Setup the MIP services
@@ -289,4 +288,4 @@ bool Services::mip3dmGpioStateWrite(Mip3dmGpioStateWriteSrv::Request& req, Mip3d
 
   return !!mip_cmd_result;
 }
-}  // namespace microstrain;
+}  // namespace microstrain

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -287,5 +287,35 @@ bool Services::mip3dmGpioStateWrite(Mip3dmGpioStateWriteSrv::Request& req, Mip3d
 
   return !!mip_cmd_result;
 }
+bool Services::mipEnableConservativeRTKMode(EmptySrv::Request& req, EmptySrv::Response& res)
+{
+  const mip::CmdResult mip_cmd_result = mip::commands_system::writeCommMode(*(config_->mip_device_), 0x05);
+  if (!!mip_cmd_result)
+    MICROSTRAIN_DEBUG(node_, "Device in Direct mode to Receiver 1");
+  else
+    MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set the receiver to directo mode.");
 
+
+  //Here, we need to send the raw configuration bytes to the receiver to enable CAR mode for the RTK algorithm.
+  //First, define the UBX configuration bytes in a buffer. These are the raw bytes requred to write the RTK-Conservative Ambiguity Resolution mode to the receiver's RAM. 
+  uint8_t data[] = {0xB5, 0x62, 0x06, 0x8A, 0x09, 0x00, 0x00, 0x01, 0x00, 0x00, 0x11, 0x00, 0x14, 0x20, 0x05, 0xe4, 0x07 };
+  size_t size = 17;
+  bool result = (config_->mip_device_)->send(data, size);
+  if (!!result)
+    MICROSTRAIN_DEBUG(node_, "Receiver configuration bytes sent sucessfully.");
+  else 
+    MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
+
+
+  const mip::CmdResult mip_cmd_result = mip::commands_system::writeCommMode(*(config_->mip_device_), 0x01); //put the device back into normal mode
+  if (!!mip_cmd_result)
+    MICROSTRAIN_DEBUG(node_, "Device returned to Normal Mode.");
+  else
+    MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set the receiver to normal mode. Power cycle device.");
+
+
+//  bool res = mip::Interface::sendToDevice(data, size);
+
+
+}
 }  // namespace microstrain

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -31,6 +31,8 @@ bool Services::configure()
     raw_file_config_aux_write_service_ = createService<RawFileConfigWriteSrv>(node_, RAW_FILE_CONFIG_AUX_WRITE_SERVICE, &Services::rawFileConfigAuxWrite, this);
   }
 
+  
+
   // Setup the MIP services
   {
     using namespace mip::commands_base;  // NOLINT(build/namespaces)
@@ -47,6 +49,10 @@ bool Services::configure()
   {
     using namespace mip::commands_filter;  // NOLINT(build/namespaces)
     mip_filter_reset_service_ = configureService<EmptySrv, Reset>(MIP_FILTER_RESET_SERVICE, &Services::mipFilterReset);
+  }
+  {
+    using namespace mip::commands_system;
+    mip_enable_conservative_rtk_service_ = configureService<EmptySrv, CommMode>(MIP_CONSERVATIVE_RTK_ENABLE_SERVICE, &Services::mipEnableConservativeRTKMode);
   }
 
   return true;
@@ -307,15 +313,15 @@ bool Services::mipEnableConservativeRTKMode(EmptySrv::Request& req, EmptySrv::Re
     MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
 
 
-  const mip::CmdResult mip_cmd_result = mip::commands_system::writeCommMode(*(config_->mip_device_), 0x01); //put the device back into normal mode
-  if (!!mip_cmd_result)
+  const mip::CmdResult mip_cmd_result_1 = mip::commands_system::writeCommMode(*(config_->mip_device_), 0x01); //put the device back into normal mode
+  if (!!mip_cmd_result_1)
     MICROSTRAIN_DEBUG(node_, "Device returned to Normal Mode.");
   else
-    MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set the receiver to normal mode. Power cycle device.");
+    MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result_1, "Failed to set the receiver to normal mode. Power cycle device.");
 
 
 //  bool res = mip::Interface::sendToDevice(data, size);
 
 
 }
-}  // namespace microstrain
+}  // namespace microstrain;

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -50,10 +50,6 @@ bool Services::configure()
     using namespace mip::commands_filter;  // NOLINT(build/namespaces)
     mip_filter_reset_service_ = configureService<EmptySrv, Reset>(MIP_FILTER_RESET_SERVICE, &Services::mipFilterReset);
   }
-  {
-    using namespace mip::commands_system;
-    mip_enable_conservative_rtk_service_ = configureService<EmptySrv, CommMode>(MIP_CONSERVATIVE_RTK_ENABLE_SERVICE, &Services::mipEnableConservativeRTKMode);
-  }
 
   return true;
 }
@@ -292,36 +288,5 @@ bool Services::mip3dmGpioStateWrite(Mip3dmGpioStateWriteSrv::Request& req, Mip3d
     MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to write GPIO state");
 
   return !!mip_cmd_result;
-}
-bool Services::mipEnableConservativeRTKMode(EmptySrv::Request& req, EmptySrv::Response& res)
-{
-  const mip::CmdResult mip_cmd_result = mip::commands_system::writeCommMode(*(config_->mip_device_), 0x05);
-  if (!!mip_cmd_result)
-    MICROSTRAIN_DEBUG(node_, "Device in Direct mode to Receiver 1");
-  else
-    MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result, "Failed to set the receiver to directo mode.");
-
-
-  //Here, we need to send the raw configuration bytes to the receiver to enable CAR mode for the RTK algorithm.
-  //First, define the UBX configuration bytes in a buffer. These are the raw bytes requred to write the RTK-Conservative Ambiguity Resolution mode to the receiver's RAM. 
-  uint8_t data[] = {0xB5, 0x62, 0x06, 0x8A, 0x09, 0x00, 0x00, 0x01, 0x00, 0x00, 0x11, 0x00, 0x14, 0x20, 0x05, 0xe4, 0x07 };
-  size_t size = 17;
-  bool result = (config_->mip_device_)->send(data, size);
-  if (!!result)
-    MICROSTRAIN_DEBUG(node_, "Receiver configuration bytes sent sucessfully.");
-  else 
-    MICROSTRAIN_DEBUG(node_, "Failed to write bytes to receiver");
-
-
-  const mip::CmdResult mip_cmd_result_1 = mip::commands_system::writeCommMode(*(config_->mip_device_), 0x01); //put the device back into normal mode
-  if (!!mip_cmd_result_1)
-    MICROSTRAIN_DEBUG(node_, "Device returned to Normal Mode.");
-  else
-    MICROSTRAIN_MIP_SDK_ERROR(node_, mip_cmd_result_1, "Failed to set the receiver to normal mode. Power cycle device.");
-
-
-//  bool res = mip::Interface::sendToDevice(data, size);
-
-
 }
 }  // namespace microstrain;


### PR DESCRIPTION
This addition adds a param: enable_conservative_rtk (default is False) that will enable the conservative ambiguity fix mode on the internal receivers on the GQ7. This may result in a longer time to first fix and mode float solutions and results in a nearly certain RTK fix.

