### PR TITLE
Support for GNSS4 and GNSS5 descriptor sets

### DIFF
--- a/config/params.yml
+++ b/config/params.yml
@@ -103,6 +103,8 @@ map_frame_id       : "map"
 earth_frame_id     : "earth"
 gnss1_frame_id     : "gnss_1_antenna_link"
 gnss2_frame_id     : "gnss_2_antenna_link"
+gnss4_frame_id     : "gnss_4_antenna_link"
+gnss5_frame_id     : "gnss_5_antenna_link"
 odometer_frame_id  : "odometer_link"
 
 # Target frame ID to publish transform to. Note that there needs to be some path of transforms between this and frame_id

--- a/config/params.yml
+++ b/config/params.yml
@@ -476,6 +476,22 @@ gnss2_velocity_ecef_data_rate  : 0  # Rate of gnss_2/velocity_ecef topic
 gnss2_odometry_earth_data_rate : 0  # Rate of gnss_2/odometry_earth topic
 gnss2_time_data_rate           : 0  # Rate of gnss_2/time topic
 
+gnss4_llh_position_data_rate   : 2 # Rate of gnss_4/llh_position topic
+gnss4_velocity_data_rate       : 2 # Rate of gnss_4/velocity topic
+gnss4_velocity_ecef_data_rate  : 0 # Rate of gnss_4/velocity topic
+                                    # Note: gnss2_odometry_earth_data_rate depends on the contents of this message.
+                                    #       If it is set to a higher value, this message will be published at that rate.
+gnss4_odometry_earth_data_rate : 0 # Rate of gnss_4/odometry_earth topic
+gnss4_time_data_rate           : 0 # Rate of gnss_4/time topic
+
+gnss5_llh_position_data_rate   : 2 # Rate of gnss_5/llh_position topic
+gnss5_velocity_data_rate       : 2 # Rate of gnss_5/velocity topic
+gnss5_velocity_ecef_data_rate  : 0 # Rate of gnss_5/velocity topic
+                                    # Note: gnss2_odometry_earth_data_rate depends on the contents of this message.
+                                    #       If it is set to a higher value, this message will be published at that rate.
+gnss5_odometry_earth_data_rate : 0 # Rate of gnss_5/odometry_earth topic
+gnss5_time_data_rate           : 0 # Rate of gnss_5/time topic
+
 # The speed at which the individual Filter publishers will publish at.
 filter_human_readable_status_data_rate : 1  # Rate of ekf/status
 filter_imu_data_rate                   : 0  # Rate of ekf/imu/data topic

--- a/config/params.yml
+++ b/config/params.yml
@@ -522,6 +522,12 @@ mip_gnss2_fix_info_data_rate           : 0  # Rate of mip/gnss_1/fix_info topic
 mip_gnss2_sbas_info_data_rate          : 0  # Rate of mip/gnss_2/sbas_info topic
 mip_gnss2_rf_error_detection_data_rate : 0  # Rate of mip/gnss_2/rf_error_detection
 
+mip_gnss4_fix_info_data_rate           : 0  # Rate of mip/gnss_4/fix_info topic
+mip_gnss4_rf_error_detection_data_rate : 0  # Rate of mip/gnss_4/rf_error_detection
+
+mip_gnss5_fix_info_data_rate           : 0  # Rate of mip/gnss_5/fix_info topic
+mip_gnss5_rf_error_detection_data_rate : 0  # Rate of mip/gnss_5/rf_error_detection
+
 mip_filter_status_data_rate                          : 0  # Rate of mip/filter/status topic
 mip_filter_gnss_position_aiding_status_data_rate     : 0  # Rate of mip/filter/gnss_aiding_status
                                                           # Note: filter_llh_position_data_rate depends on the contents of this message.

--- a/include/microstrain_inertial_driver_common/publishers.h
+++ b/include/microstrain_inertial_driver_common/publishers.h
@@ -242,11 +242,11 @@ public:
   Publisher<TwistWithCovarianceStampedMsg>::SharedPtr wheel_speed_pub_ = Publisher<TwistWithCovarianceStampedMsg>::initialize(IMU_WHEEL_SPEED_TOPIC);
 
   // GNSS publishers
-  Publisher<NavSatFixMsg>::SharedPtrVec                  gnss_llh_position_pub_  = Publisher<NavSatFixMsg>::initializeVec({GNSS1_LLH_POSITION_TOPIC, GNSS2_FIX_TOPIC});
-  Publisher<TwistWithCovarianceStampedMsg>::SharedPtrVec gnss_velocity_pub_      = Publisher<TwistWithCovarianceStampedMsg>::initializeVec({GNSS1_VELOCITY_TOPIC, GNSS2_VELOCITY_TOPIC});
-  Publisher<TwistWithCovarianceStampedMsg>::SharedPtrVec gnss_velocity_ecef_pub_ = Publisher<TwistWithCovarianceStampedMsg>::initializeVec({GNSS1_VELOCITY_ECEF_TOPIC, GNSS2_VELOCITY_ECEF_TOPIC});
-  Publisher<OdometryMsg>::SharedPtrVec                   gnss_odometry_pub_      = Publisher<OdometryMsg>::initializeVec({GNSS1_ODOMETRY_TOPIC, GNSS2_ODOMETRY_TOPIC});
-  Publisher<TimeReferenceMsg>::SharedPtrVec              gnss_time_pub_          = Publisher<TimeReferenceMsg>::initializeVec({GNSS1_TIME_REF_TOPIC, GNSS2_TIME_REF_TOPIC});
+  Publisher<NavSatFixMsg>::SharedPtrVec                  gnss_llh_position_pub_  = Publisher<NavSatFixMsg>::initializeVec({GNSS1_LLH_POSITION_TOPIC, GNSS2_FIX_TOPIC, GNSS4_FIX_TOPIC, GNSS5_FIX_TOPIC}); 
+  Publisher<TwistWithCovarianceStampedMsg>::SharedPtrVec gnss_velocity_pub_      = Publisher<TwistWithCovarianceStampedMsg>::initializeVec({GNSS1_VELOCITY_TOPIC, GNSS2_VELOCITY_TOPIC, GNSS4_VELOCITY_TOPIC, GNSS5_VELOCITY_TOPIC});
+  Publisher<TwistWithCovarianceStampedMsg>::SharedPtrVec gnss_velocity_ecef_pub_ = Publisher<TwistWithCovarianceStampedMsg>::initializeVec({GNSS1_VELOCITY_ECEF_TOPIC, GNSS2_VELOCITY_ECEF_TOPIC, GNSS4_VELOCITY_ECEF_TOPIC, GNSS5_VELOCITY_ECEF_TOPIC});
+  Publisher<OdometryMsg>::SharedPtrVec                   gnss_odometry_pub_      = Publisher<OdometryMsg>::initializeVec({GNSS1_ODOMETRY_TOPIC, GNSS2_ODOMETRY_TOPIC, GNSS4_ODOMETRY_TOPIC, GNSS5_ODOMETRY_TOPIC});
+  Publisher<TimeReferenceMsg>::SharedPtrVec              gnss_time_pub_          = Publisher<TimeReferenceMsg>::initializeVec({GNSS1_TIME_REF_TOPIC, GNSS2_TIME_REF_TOPIC, GNSS4_TIME_REF_TOPIC, GNSS5_TIME_REF_TOPIC});
 
   // Filter publishers
   Publisher<HumanReadableStatusMsg>::SharedPtr            filter_human_readable_status_pub_ = Publisher<HumanReadableStatusMsg>::initialize(FILTER_HUMAN_READABLE_STATUS_TOPIC);

--- a/include/microstrain_inertial_driver_common/publishers.h
+++ b/include/microstrain_inertial_driver_common/publishers.h
@@ -264,9 +264,9 @@ public:
   Publisher<MipSensorTemperatureStatisticsMsg>::SharedPtr mip_sensor_temperature_statistics_pub_ = Publisher<MipSensorTemperatureStatisticsMsg>::initialize(MIP_SENSOR_TEMPERATURE_STATISTICS_TOPIC);
 
   // MIP GNSS (0x81, 0x91, 0x92) publishers
-  Publisher<MipGnssFixInfoMsg>::SharedPtrVec          mip_gnss_fix_info_pub_           = Publisher<MipGnssFixInfoMsg>::initializeVec({MIP_GNSS1_FIX_INFO_TOPIC, MIP_GNSS2_FIX_INFO_TOPIC});
+  Publisher<MipGnssFixInfoMsg>::SharedPtrVec          mip_gnss_fix_info_pub_           = Publisher<MipGnssFixInfoMsg>::initializeVec({MIP_GNSS1_FIX_INFO_TOPIC, MIP_GNSS2_FIX_INFO_TOPIC, MIP_GNSS4_FIX_INFO_TOPIC, MIP_GNSS5_FIX_INFO_TOPIC}); 
   Publisher<MipGnssSbasInfoMsg>::SharedPtrVec         mip_gnss_sbas_info_pub_          = Publisher<MipGnssSbasInfoMsg>::initializeVec({MIP_GNSS1_SBAS_INFO_TOPIC, MIP_GNSS2_SBAS_INFO_TOPIC});
-  Publisher<MipGnssRfErrorDetectionMsg>::SharedPtrVec mip_gnss_rf_error_detection_pub_ = Publisher<MipGnssRfErrorDetectionMsg>::initializeVec({MIP_GNSS1_RF_ERROR_DETECTION_TOPIC, MIP_GNSS2_RF_ERROR_DETECTION_TOPIC});
+  Publisher<MipGnssRfErrorDetectionMsg>::SharedPtrVec mip_gnss_rf_error_detection_pub_ = Publisher<MipGnssRfErrorDetectionMsg>::initializeVec({MIP_GNSS1_RF_ERROR_DETECTION_TOPIC, MIP_GNSS2_RF_ERROR_DETECTION_TOPIC, MIP_GNSS4_RF_ERROR_DETECTION_TOPIC, MIP_GNSS5_RF_ERROR_DETECTION_TOPIC});
 
   // MIP GNSS Corrections (0x93) publishers
   Publisher<MipGnssCorrectionsRtkCorrectionsStatusMsg>::SharedPtr mip_gnss_corrections_rtk_corrections_status_pub_ = Publisher<MipGnssCorrectionsRtkCorrectionsStatusMsg>::initialize(MIP_GNSS_CORRECTIONS_RTK_CORRECTIONS_STATUS_TOPIC);

--- a/include/microstrain_inertial_driver_common/utils/mappings/mip_publisher_mapping.h
+++ b/include/microstrain_inertial_driver_common/utils/mappings/mip_publisher_mapping.h
@@ -45,6 +45,18 @@ static constexpr auto GNSS2_VELOCITY_ECEF_TOPIC = "gnss_2/velocity_ecef";
 static constexpr auto GNSS2_ODOMETRY_TOPIC = "gnss_2/odometry_earth";
 static constexpr auto GNSS2_TIME_REF_TOPIC = "gnss_2/time";
 
+static constexpr auto GNSS4_FIX_TOPIC = "gnss_4/llh_position";
+static constexpr auto GNSS4_VELOCITY_TOPIC = "gnss_4/velocity";
+static constexpr auto GNSS4_VELOCITY_ECEF_TOPIC = "gnss_4/velocity_ecef";
+static constexpr auto GNSS4_ODOMETRY_TOPIC = "gnss_4/odometry_earth";
+static constexpr auto GNSS4_TIME_REF_TOPIC = "gnss_4/time";
+
+static constexpr auto GNSS5_FIX_TOPIC = "gnss_5/llh_position";
+static constexpr auto GNSS5_VELOCITY_TOPIC = "gnss_5/velocity";
+static constexpr auto GNSS5_VELOCITY_ECEF_TOPIC = "gnss_5/velocity_ecef";
+static constexpr auto GNSS5_ODOMETRY_TOPIC = "gnss_5/odometry_earth";
+static constexpr auto GNSS5_TIME_REF_TOPIC = "gnss_5/time";
+
 static constexpr auto FILTER_HUMAN_READABLE_STATUS_TOPIC = "ekf/status";
 static constexpr auto FILTER_IMU_DATA_TOPIC = "ekf/imu/data";
 static constexpr auto FILTER_LLH_POSITION_TOPIC = "ekf/llh_position";

--- a/include/microstrain_inertial_driver_common/utils/mappings/mip_publisher_mapping.h
+++ b/include/microstrain_inertial_driver_common/utils/mappings/mip_publisher_mapping.h
@@ -77,6 +77,12 @@ static constexpr auto MIP_GNSS2_FIX_INFO_TOPIC = "mip/gnss_2/fix_info";
 static constexpr auto MIP_GNSS2_SBAS_INFO_TOPIC = "mip/gnss_2/sbas_info";
 static constexpr auto MIP_GNSS2_RF_ERROR_DETECTION_TOPIC = "mip/gnss_2/rf_error_detection";
 
+static constexpr auto MIP_GNSS4_FIX_INFO_TOPIC = "mip/gnss_4/fix_info";
+static constexpr auto MIP_GNSS4_RF_ERROR_DETECTION_TOPIC = "mip/gnss_4/rf_error_detection";
+
+static constexpr auto MIP_GNSS5_FIX_INFO_TOPIC = "mip/gnss_5/fix_info";
+static constexpr auto MIP_GNSS5_RF_ERROR_DETECTION_TOPIC = "mip/gnss_5/rf_error_detection";
+
 static constexpr auto MIP_GNSS_CORRECTIONS_RTK_CORRECTIONS_STATUS_TOPIC = "mip/gnss_corrections/rtk_corrections_status";
 
 static constexpr auto MIP_FILTER_STATUS_TOPIC = "mip/ekf/status";

--- a/include/microstrain_inertial_driver_common/utils/ros_compat.h
+++ b/include/microstrain_inertial_driver_common/utils/ros_compat.h
@@ -38,7 +38,10 @@ constexpr auto GPS_LEAP_SECONDS = 18;
 
 constexpr auto GNSS1_ID = 0;
 constexpr auto GNSS2_ID = 1;
-constexpr auto NUM_GNSS = 2;
+constexpr auto GNSS4_ID = 2;
+constexpr auto GNSS5_ID = 3;
+
+constexpr auto NUM_GNSS = 4;
 };  // namespace microstrain
 
 /**

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -81,6 +81,8 @@ bool Config::configure(RosNodeType* node)
   getParam<std::string>(node, "earth_frame_id", earth_frame_id_, "earth");
   getParam<std::string>(node, "gnss1_frame_id", gnss_frame_id_[GNSS1_ID], "gnss_1_antenna_link");
   getParam<std::string>(node, "gnss2_frame_id", gnss_frame_id_[GNSS2_ID], "gnss_2_antenna_link");
+  getParam<std::string>(node, "gnss4_frame_id", gnss_frame_id_[GNSS4_ID], "gnss_4_antenna_link");
+  getParam<std::string>(node, "gnss5_frame_id", gnss_frame_id_[GNSS5_ID], "gnss_5_antenna_link");
   getParam<std::string>(node, "odometer_frame_id", odometer_frame_id_, "odometer_link");
   getParam<bool>(node, "use_enu_frame", use_enu_frame_, false);
 

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -100,7 +100,7 @@ uint8_t getGNSSIndex(const uint8_t gnss_descriptor_set)
       return 3;
       break;
     default:
-      return 0; // TODO: ask rob about default case
+      return 0; //
   }
 }
 
@@ -168,17 +168,13 @@ bool Publishers::configure()
   pressure_pub_->getMessage()->header.frame_id = config_->frame_id_;
   wheel_speed_pub_->getMessage()->header.frame_id = config_->odometer_frame_id_;
 
-  MICROSTRAIN_DEBUG(node_, "configured all publishers before gnss");//TODO: REMOVE
-  printf("testing testing \n");
   for (int i = 0; i < gnss_llh_position_pub_.size(); i++) gnss_llh_position_pub_[i]->getMessage()->header.frame_id = config_->gnss_frame_id_[i];
-  MICROSTRAIN_DEBUG(node_, "configured all publishers after first gnss");//TODO: REMOVE
   for (int i = 0; i < gnss_velocity_pub_.size(); i++) gnss_velocity_pub_[i]->getMessage()->header.frame_id = config_->gnss_frame_id_[i];
   for (int i = 0; i < gnss_velocity_ecef_pub_.size(); i++) gnss_velocity_ecef_pub_[i]->getMessage()->header.frame_id = config_->gnss_frame_id_[i];
   for (int i = 0; i < gnss_odometry_pub_.size(); i++) gnss_odometry_pub_[i]->getMessage()->header.frame_id = config_->earth_frame_id_;
   for (int i = 0; i < gnss_odometry_pub_.size(); i++) gnss_odometry_pub_[i]->getMessage()->child_frame_id = config_->gnss_frame_id_[i];
   for (int i = 0; i < gnss_time_pub_.size(); i++) gnss_time_pub_[i]->getMessage()->header.frame_id = config_->gnss_frame_id_[i];
 
-  MICROSTRAIN_DEBUG(node_, "configured all publishers after gnss"); //TODO: REMOVE
 
   filter_human_readable_status_pub_->getMessage()->header.frame_id = config_->frame_id_;
   filter_imu_pub_->getMessage()->header.frame_id = config_->frame_id_;
@@ -2133,7 +2129,7 @@ void Publishers::updateMipHeader(MipHeaderMsg* mip_header, uint8_t descriptor_se
   // Update the ROS header with the ROS timestamp
   updateHeaderTime(&mip_header->header, descriptor_set, timestamp, gps_timestamp);
 
-  // Default frame ID is determined by the descriptor set TODO: UPDATE
+  // Default frame ID is determined by the descriptor set
   if (descriptor_set == mip::data_gnss::DESCRIPTOR_SET || descriptor_set == mip::data_gnss::MIP_GNSS1_DATA_DESC_SET)
     mip_header->header.frame_id = config_->gnss_frame_id_[GNSS1_ID];
   else if (descriptor_set == mip::data_gnss::MIP_GNSS2_DATA_DESC_SET)

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -81,6 +81,29 @@ Publishers::Publishers(RosNodeType* node, Config* config)
   transform_listener_ = createTransformListener(transform_buffer_);
 }
 
+// Helper function to return GNSS index
+uint8_t getGNSSIndex(const uint8_t gnss_descriptor_set)
+{
+  switch (gnss_descriptor_set)
+  {
+    case mip::data_gnss::DESCRIPTOR_SET:
+    case mip::data_gnss::MIP_GNSS1_DATA_DESC_SET:
+      return 0;
+      break;
+    case mip::data_gnss::MIP_GNSS2_DATA_DESC_SET:
+      return 1;
+      break;
+    case mip::data_gnss::MIP_GNSS4_DATA_DESC_SET:
+      return 2;
+      break;
+    case mip::data_gnss::MIP_GNSS5_DATA_DESC_SET:
+      return 3;
+      break;
+    default:
+      return 0; // TODO: ask rob about default case
+  }
+}
+
 bool Publishers::configure()
 {
   imu_raw_pub_->configure(node_, config_);
@@ -88,7 +111,7 @@ bool Publishers::configure()
   mag_pub_->configure(node_, config_);
   pressure_pub_->configure(node_, config_);
   wheel_speed_pub_->configure(node_, config_);
-
+ 
   for (const auto& pub : gnss_llh_position_pub_) pub->configure(node_, config_);
   for (const auto& pub : gnss_velocity_pub_) pub->configure(node_, config_);
   for (const auto& pub : gnss_velocity_ecef_pub_) pub->configure(node_, config_);
@@ -145,12 +168,17 @@ bool Publishers::configure()
   pressure_pub_->getMessage()->header.frame_id = config_->frame_id_;
   wheel_speed_pub_->getMessage()->header.frame_id = config_->odometer_frame_id_;
 
+  MICROSTRAIN_DEBUG(node_, "configured all publishers before gnss");//TODO: REMOVE
+  printf("testing testing \n");
   for (int i = 0; i < gnss_llh_position_pub_.size(); i++) gnss_llh_position_pub_[i]->getMessage()->header.frame_id = config_->gnss_frame_id_[i];
+  MICROSTRAIN_DEBUG(node_, "configured all publishers after first gnss");//TODO: REMOVE
   for (int i = 0; i < gnss_velocity_pub_.size(); i++) gnss_velocity_pub_[i]->getMessage()->header.frame_id = config_->gnss_frame_id_[i];
   for (int i = 0; i < gnss_velocity_ecef_pub_.size(); i++) gnss_velocity_ecef_pub_[i]->getMessage()->header.frame_id = config_->gnss_frame_id_[i];
   for (int i = 0; i < gnss_odometry_pub_.size(); i++) gnss_odometry_pub_[i]->getMessage()->header.frame_id = config_->earth_frame_id_;
   for (int i = 0; i < gnss_odometry_pub_.size(); i++) gnss_odometry_pub_[i]->getMessage()->child_frame_id = config_->gnss_frame_id_[i];
   for (int i = 0; i < gnss_time_pub_.size(); i++) gnss_time_pub_[i]->getMessage()->header.frame_id = config_->gnss_frame_id_[i];
+
+  MICROSTRAIN_DEBUG(node_, "configured all publishers after gnss"); //TODO: REMOVE
 
   filter_human_readable_status_pub_->getMessage()->header.frame_id = config_->frame_id_;
   filter_imu_pub_->getMessage()->header.frame_id = config_->frame_id_;
@@ -328,7 +356,7 @@ bool Publishers::configure()
 
   // Register callbacks for each data field we care about. Note that order is preserved here, so if a data field needs to be parsed before another, change it here.
   // Prospect shared field callbacks
-  for (const uint8_t descriptor_set : std::initializer_list<uint8_t>{mip::data_sensor::DESCRIPTOR_SET, mip::data_gnss::DESCRIPTOR_SET, mip::data_gnss::MIP_GNSS1_DATA_DESC_SET, mip::data_gnss::MIP_GNSS2_DATA_DESC_SET, mip::data_gnss::MIP_GNSS3_DATA_DESC_SET, mip::data_filter::DESCRIPTOR_SET, mip::data_system::DESCRIPTOR_SET})
+  for (const uint8_t descriptor_set : std::initializer_list<uint8_t>{mip::data_sensor::DESCRIPTOR_SET, mip::data_gnss::DESCRIPTOR_SET, mip::data_gnss::MIP_GNSS1_DATA_DESC_SET, mip::data_gnss::MIP_GNSS2_DATA_DESC_SET, mip::data_gnss::MIP_GNSS3_DATA_DESC_SET, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET, mip::data_filter::DESCRIPTOR_SET, mip::data_system::DESCRIPTOR_SET})
   {
     registerDataCallback<mip::data_shared::EventSource, &Publishers::handleSharedEventSource>(descriptor_set);
     registerDataCallback<mip::data_shared::Ticks, &Publishers::handleSharedTicks>(descriptor_set);
@@ -356,8 +384,8 @@ bool Publishers::configure()
   registerDataCallback<mip::data_sensor::OverrangeStatus, &Publishers::handleSensorOverrangeStatus>();
   registerDataCallback<mip::data_sensor::TemperatureAbs, &Publishers::handleSensorTemperatureStatistics>();
 
-  // GNSS1/2 callbacks
-  for (const uint8_t gnss_descriptor_set : std::initializer_list<uint8_t>{mip::data_gnss::DESCRIPTOR_SET, mip::data_gnss::MIP_GNSS1_DATA_DESC_SET, mip::data_gnss::MIP_GNSS2_DATA_DESC_SET})
+  // GNSS1/2 callbacks and GNSS4/5 callbacks
+  for (const uint8_t gnss_descriptor_set : std::initializer_list<uint8_t>{mip::data_gnss::DESCRIPTOR_SET, mip::data_gnss::MIP_GNSS1_DATA_DESC_SET, mip::data_gnss::MIP_GNSS2_DATA_DESC_SET, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET})
   {
     registerDataCallback<mip::data_gnss::PosLlh, &Publishers::handleGnssPosLlh>(gnss_descriptor_set);
     registerDataCallback<mip::data_gnss::VelNed, &Publishers::handleGnssVelNed>(gnss_descriptor_set);
@@ -369,7 +397,7 @@ bool Publishers::configure()
   }
 
   // Note: It is important to make sure this is after the GNSS1/2 callbacks
-  for (const uint8_t gnss_descriptor_set : std::initializer_list<uint8_t>{mip::data_gnss::MIP_GNSS1_DATA_DESC_SET, mip::data_gnss::MIP_GNSS2_DATA_DESC_SET})
+  for (const uint8_t gnss_descriptor_set : std::initializer_list<uint8_t>{mip::data_gnss::MIP_GNSS1_DATA_DESC_SET, mip::data_gnss::MIP_GNSS2_DATA_DESC_SET, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET})
   {
     registerDataCallback<mip::data_gnss::GpsTime, &Publishers::handleGnssGpsTime>(gnss_descriptor_set);
   }
@@ -663,18 +691,8 @@ void Publishers::handleSharedGpsTimestamp(const mip::data_shared::GpsTimestamp& 
   gps_timestamp_mapping_[descriptor_set] = gps_timestamp;
 
   // Update the GPS time message for this descriptor
-  uint8_t gnss_index;
-  switch (descriptor_set)
-  {
-    case mip::data_gnss::MIP_GNSS1_DATA_DESC_SET:
-      gnss_index = 0;
-      break;
-    case mip::data_gnss::MIP_GNSS2_DATA_DESC_SET:
-      gnss_index = 1;
-      break;
-    default:
-      return;
-  }
+  uint8_t gnss_index = getGNSSIndex(descriptor_set);
+
   auto gps_time_msg = gnss_time_pub_[gnss_index]->getMessageToUpdate();
   gps_time_msg->header.stamp = rosTimeNow(node_);
   setGpsTime(&gps_time_msg->time_ref, gps_timestamp);
@@ -870,19 +888,7 @@ void Publishers::handleGnssGpsTime(const mip::data_gnss::GpsTime& gps_time, cons
   gps_timestamp_mapping_[descriptor_set] = stored_timestamp;
 
   // Also update the time ref messages
-  uint8_t gnss_index;
-  switch (descriptor_set)
-  {
-    case mip::data_gnss::DESCRIPTOR_SET:
-    case mip::data_gnss::MIP_GNSS1_DATA_DESC_SET:
-      gnss_index = 0;
-      break;
-    case mip::data_gnss::MIP_GNSS2_DATA_DESC_SET:
-      gnss_index = 1;
-      break;
-    default:
-      return;
-  }
+  uint8_t gnss_index = getGNSSIndex(descriptor_set);
   auto gps_time_msg = gnss_time_pub_[gnss_index]->getMessageToUpdate();
   gps_time_msg->header.stamp = rosTimeNow(node_);
   setGpsTime(&gps_time_msg->time_ref, stored_timestamp);
@@ -891,8 +897,7 @@ void Publishers::handleGnssGpsTime(const mip::data_gnss::GpsTime& gps_time, cons
 void Publishers::handleGnssPosLlh(const mip::data_gnss::PosLlh& pos_llh, const uint8_t descriptor_set, mip::Timestamp timestamp)
 {
   // Different message depending on the descriptor set
-  const uint8_t gnss_index = (descriptor_set == mip::data_gnss::DESCRIPTOR_SET || descriptor_set == mip::data_gnss::MIP_GNSS1_DATA_DESC_SET) ? GNSS1_ID : GNSS2_ID;
-
+  uint8_t gnss_index = getGNSSIndex(descriptor_set);
   // GNSS navsatfix message
   auto gnss_llh_position_msg = gnss_llh_position_pub_[gnss_index]->getMessageToUpdate();
   updateHeaderTime(&(gnss_llh_position_msg->header), descriptor_set, timestamp);
@@ -909,8 +914,7 @@ void Publishers::handleGnssPosLlh(const mip::data_gnss::PosLlh& pos_llh, const u
 void Publishers::handleGnssVelNed(const mip::data_gnss::VelNed& vel_ned, const uint8_t descriptor_set, mip::Timestamp timestamp)
 {
   // Different message depending on the descriptor set
-  const uint8_t gnss_index = (descriptor_set == mip::data_gnss::DESCRIPTOR_SET || descriptor_set == mip::data_gnss::MIP_GNSS1_DATA_DESC_SET) ? GNSS1_ID : GNSS2_ID;
-
+  uint8_t gnss_index = getGNSSIndex(descriptor_set);
   // GNSS velocity message
   auto gnss_velocity_msg = gnss_velocity_pub_[gnss_index]->getMessageToUpdate();
   updateHeaderTime(&(gnss_velocity_msg->header), descriptor_set, timestamp);
@@ -978,7 +982,8 @@ void Publishers::handleGnssVelNed(const mip::data_gnss::VelNed& vel_ned, const u
 void Publishers::handleGnssPosEcef(const mip::data_gnss::PosEcef& pos_ecef, const uint8_t descriptor_set, mip::Timestamp timestamp)
 {
   // Different message depending on the descriptor set
-  const uint8_t gnss_index = (descriptor_set == mip::data_gnss::DESCRIPTOR_SET || descriptor_set == mip::data_gnss::MIP_GNSS1_DATA_DESC_SET) ? GNSS1_ID : GNSS2_ID;
+  uint8_t gnss_index = getGNSSIndex(descriptor_set);
+
   auto gnss_odometry_msg = gnss_odometry_pub_[gnss_index]->getMessageToUpdate();
   updateHeaderTime(&(gnss_odometry_msg->header), descriptor_set, timestamp);
   gnss_odometry_msg->pose.pose.position.x = pos_ecef.x[0];
@@ -992,7 +997,7 @@ void Publishers::handleGnssPosEcef(const mip::data_gnss::PosEcef& pos_ecef, cons
 void Publishers::handleGnssVelEcef(const mip::data_gnss::VelEcef& vel_ecef, const uint8_t descriptor_set, mip::Timestamp timestamp)
 {
   // Different message depending on the descriptor set
-  const uint8_t gnss_index = (descriptor_set == mip::data_gnss::DESCRIPTOR_SET || descriptor_set == mip::data_gnss::MIP_GNSS1_DATA_DESC_SET) ? GNSS1_ID : GNSS2_ID;
+  const uint8_t gnss_index = getGNSSIndex(descriptor_set);
   auto gnss_velocity_ecef_msg = gnss_velocity_ecef_pub_[gnss_index]->getMessageToUpdate();
   updateHeaderTime(&(gnss_velocity_ecef_msg->header), descriptor_set, timestamp);
   gnss_velocity_ecef_msg->twist.twist.linear.x = vel_ecef.v[0];
@@ -1006,7 +1011,7 @@ void Publishers::handleGnssVelEcef(const mip::data_gnss::VelEcef& vel_ecef, cons
 void Publishers::handleGnssFixInfo(const mip::data_gnss::FixInfo& fix_info, const uint8_t descriptor_set, mip::Timestamp timestamp)
 {
   // Different message depending on the descriptor set
-  const uint8_t gnss_index = (descriptor_set == mip::data_gnss::DESCRIPTOR_SET || descriptor_set == mip::data_gnss::MIP_GNSS1_DATA_DESC_SET) ? GNSS1_ID : GNSS2_ID;
+  const uint8_t gnss_index = getGNSSIndex(descriptor_set);
 
   // GNSS Fix info message
   auto mip_gnss_fix_info_msg = mip_gnss_fix_info_pub_[gnss_index]->getMessage();
@@ -1032,18 +1037,7 @@ void Publishers::handleGnssFixInfo(const mip::data_gnss::FixInfo& fix_info, cons
 void Publishers::handleGnssRfErrorDetection(const mip::data_gnss::RfErrorDetection& rf_error_detection, const uint8_t descriptor_set, mip::Timestamp timestamp)
 {
   // Find the right index for the message
-  uint8_t gnss_index;
-  switch (descriptor_set)
-  {
-    case mip::data_gnss::MIP_GNSS1_DATA_DESC_SET:
-      gnss_index = 0;
-      break;
-    case mip::data_gnss::MIP_GNSS2_DATA_DESC_SET:
-      gnss_index = 1;
-      break;
-    default:
-      return;  // Nothing to do if the descriptor set is not something we recognize
-  }
+  uint8_t gnss_index = getGNSSIndex(descriptor_set);
 
   // Different message depending on the descriptor set
   auto mip_gnss_rf_error_detection_msg = mip_gnss_rf_error_detection_pub_[gnss_index]->getMessage();
@@ -1057,18 +1051,7 @@ void Publishers::handleGnssRfErrorDetection(const mip::data_gnss::RfErrorDetecti
 void Publishers::handleGnssSbasInfo(const mip::data_gnss::SbasInfo& sbas_info, const uint8_t descriptor_set, mip::Timestamp timestamp)
 {
   // Find the right index for the message
-  uint8_t gnss_index;
-  switch (descriptor_set)
-  {
-    case mip::data_gnss::MIP_GNSS1_DATA_DESC_SET:
-      gnss_index = 0;
-      break;
-    case mip::data_gnss::MIP_GNSS2_DATA_DESC_SET:
-      gnss_index = 1;
-      break;
-    default:
-      return;  // Nothing to do if the descriptor set is not something we recognize
-  }
+  uint8_t gnss_index = getGNSSIndex(descriptor_set);
 
   // Different message depending on descriptor
   auto mip_gnss_sbas_info_msg = mip_gnss_sbas_info_pub_[gnss_index]->getMessage();

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -2133,11 +2133,15 @@ void Publishers::updateMipHeader(MipHeaderMsg* mip_header, uint8_t descriptor_se
   // Update the ROS header with the ROS timestamp
   updateHeaderTime(&mip_header->header, descriptor_set, timestamp, gps_timestamp);
 
-  // Default frame ID is determined by the descriptor set
+  // Default frame ID is determined by the descriptor set TODO: UPDATE
   if (descriptor_set == mip::data_gnss::DESCRIPTOR_SET || descriptor_set == mip::data_gnss::MIP_GNSS1_DATA_DESC_SET)
     mip_header->header.frame_id = config_->gnss_frame_id_[GNSS1_ID];
   else if (descriptor_set == mip::data_gnss::MIP_GNSS2_DATA_DESC_SET)
     mip_header->header.frame_id = config_->gnss_frame_id_[GNSS2_ID];
+  else if (descriptor_set == mip::data_gnss::MIP_GNSS4_DATA_DESC_SET)
+    mip_header->header.frame_id = config_->gnss_frame_id_[GNSS4_ID];
+  else if (descriptor_set == mip::data_gnss::MIP_GNSS5_DATA_DESC_SET)
+    mip_header->header.frame_id = config_->gnss_frame_id_[GNSS5_ID];
   else
     mip_header->header.frame_id = config_->frame_id_;
 

--- a/src/utils/mappings/mip_publisher_mapping.cpp
+++ b/src/utils/mappings/mip_publisher_mapping.cpp
@@ -480,6 +480,23 @@ const std::map<std::string, FieldWrapper::SharedPtrVec> MipPublisherMapping::sta
     FieldWrapperType<mip::data_gnss::RfErrorDetection, mip::data_gnss::MIP_GNSS2_DATA_DESC_SET>::initialize()
   }},
 
+  // MIP GNSS4 (0x94) topic mappings
+  {MIP_GNSS4_FIX_INFO_TOPIC, {
+    FieldWrapperType<mip::data_gnss::FixInfo, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET>::initialize(),
+  }},
+  {MIP_GNSS4_RF_ERROR_DETECTION_TOPIC, {
+    FieldWrapperType<mip::data_gnss::RfErrorDetection, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET>::initialize()
+  }},
+
+  // MIP GNSS5 (0x95) topic mappings
+  {MIP_GNSS5_FIX_INFO_TOPIC, {
+    FieldWrapperType<mip::data_gnss::FixInfo, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET>::initialize(),
+  }},
+  {MIP_GNSS5_RF_ERROR_DETECTION_TOPIC, {
+    FieldWrapperType<mip::data_gnss::RfErrorDetection, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET>::initialize()
+  }},
+
+
   // MIP Filter (0x82) topic mappings
   {MIP_FILTER_STATUS_TOPIC, {
     FieldWrapperType<mip::data_filter::Status>::initialize(),
@@ -566,6 +583,14 @@ const std::map<std::string, std::string> MipPublisherMapping::static_topic_to_da
   {MIP_GNSS2_FIX_INFO_TOPIC,           "mip_gnss2_fix_info_data_rate"},
   {MIP_GNSS2_SBAS_INFO_TOPIC,          "mip_gnss2_sbas_info_data_rate"},
   {MIP_GNSS2_RF_ERROR_DETECTION_TOPIC, "mip_gnss2_rf_error_detection_data_rate"},
+
+  // MIP GNSS4 (0x94) data rates
+  {MIP_GNSS4_FIX_INFO_TOPIC,           "mip_gnss4_fix_info_data_rate"},
+  {MIP_GNSS4_RF_ERROR_DETECTION_TOPIC, "mip_gnss4_rf_error_detection_data_rate"},
+
+  // MIP GNSS5 (0x95) data rates
+  {MIP_GNSS5_FIX_INFO_TOPIC,           "mip_gnss5_fix_info_data_rate"},
+  {MIP_GNSS5_RF_ERROR_DETECTION_TOPIC, "mip_gnss5_rf_error_detection_data_rate"},
 
   // MIP filter (0x82) data rates
   {MIP_FILTER_STATUS_TOPIC,                          "mip_filter_status_data_rate"},

--- a/src/utils/mappings/mip_publisher_mapping.cpp
+++ b/src/utils/mappings/mip_publisher_mapping.cpp
@@ -360,6 +360,42 @@ const std::map<std::string, FieldWrapper::SharedPtrVec> MipPublisherMapping::sta
     FieldWrapperType<mip::data_gnss::GpsTime, mip::data_gnss::MIP_GNSS2_DATA_DESC_SET>::initialize(),
   }},
 
+  // GNSS4 topic mappings.
+  {GNSS4_FIX_TOPIC, {
+    FieldWrapperType<mip::data_gnss::PosLlh, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET>::initialize(),
+  }},
+  {GNSS4_VELOCITY_TOPIC, {
+    FieldWrapperType<mip::data_gnss::VelNed, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET>::initialize(),
+  }},
+  {GNSS4_VELOCITY_ECEF_TOPIC, {
+    FieldWrapperType<mip::data_gnss::VelEcef, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET>::initialize(),
+  }},
+  {GNSS4_ODOMETRY_TOPIC, {
+    FieldWrapperType<mip::data_gnss::PosEcef, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET>::initialize(),
+    FieldWrapperType<mip::data_gnss::VelNed, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET>::initialize(),
+  }},
+  {GNSS4_TIME_REF_TOPIC, {
+    FieldWrapperType<mip::data_gnss::GpsTime, mip::data_gnss::MIP_GNSS4_DATA_DESC_SET>::initialize(),
+  }},
+  
+  // GNSS5 topic mappings.
+  {GNSS5_FIX_TOPIC, {
+    FieldWrapperType<mip::data_gnss::PosLlh, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET>::initialize(),
+  }},
+  {GNSS5_VELOCITY_TOPIC, {
+    FieldWrapperType<mip::data_gnss::VelNed, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET>::initialize(),
+  }},
+  {GNSS5_VELOCITY_ECEF_TOPIC, {
+    FieldWrapperType<mip::data_gnss::VelEcef, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET>::initialize(),
+  }},
+  {GNSS5_ODOMETRY_TOPIC, {
+    FieldWrapperType<mip::data_gnss::PosEcef, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET>::initialize(),
+    FieldWrapperType<mip::data_gnss::VelNed, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET>::initialize(),
+  }},
+  {GNSS5_TIME_REF_TOPIC, {
+    FieldWrapperType<mip::data_gnss::GpsTime, mip::data_gnss::MIP_GNSS5_DATA_DESC_SET>::initialize(),
+  }},
+
   // Filter topic mappings
   {FILTER_HUMAN_READABLE_STATUS_TOPIC, {
     FieldWrapperType<mip::data_gnss::FixInfo, mip::data_gnss::DESCRIPTOR_SET>::initialize(),
@@ -492,7 +528,21 @@ const std::map<std::string, std::string> MipPublisherMapping::static_topic_to_da
   {GNSS2_VELOCITY_ECEF_TOPIC, "gnss2_velocity_ecef_data_rate"},
   {GNSS2_ODOMETRY_TOPIC,      "gnss2_odometry_earth_data_rate"},
   {GNSS2_TIME_REF_TOPIC,      "gnss2_time_data_rate"},
-
+  
+  // GNSS4 data rates
+  {GNSS4_FIX_TOPIC,           "gnss4_llh_position_data_rate"},
+  {GNSS4_VELOCITY_TOPIC,      "gnss4_velocity_data_rate"},
+  {GNSS4_VELOCITY_ECEF_TOPIC, "gnss4_velocity_ecef_data_rate"},
+  {GNSS4_ODOMETRY_TOPIC,      "gnss4_odometry_earth_data_rate"},
+  {GNSS4_TIME_REF_TOPIC,      "gnss4_time_data_rate"},
+  
+  // GNSS5 data rates
+  {GNSS5_FIX_TOPIC,           "gnss5_llh_position_data_rate"},
+  {GNSS5_VELOCITY_TOPIC,      "gnss5_velocity_data_rate"},
+  {GNSS5_VELOCITY_ECEF_TOPIC, "gnss5_velocity_ecef_data_rate"},
+  {GNSS5_ODOMETRY_TOPIC,      "gnss5_odometry_earth_data_rate"},
+  {GNSS5_TIME_REF_TOPIC,      "gnss5_time_data_rate"},
+  
   // Filter data rates
   {FILTER_HUMAN_READABLE_STATUS_TOPIC, "filter_human_readable_status_data_rate"},
   {FILTER_IMU_DATA_TOPIC,              "filter_imu_data_rate"},


### PR DESCRIPTION
Adding publishing of the following topics for support for MicroStrain's Nova Development Board:

- /gnss_4/llh_position
- /gnss_4/velocity
- /gnss_4/velocity_ecef
- /gnss_4/odometry_earth
- /gnss_4/time
- /gnss_5/llh_position
- /gnss_5/velocity
- /gnss_5/velocity_ecef
- /gnss_5/odometry_earth
- /gnss_5/time

-/mip/gnss_4/fix_info
-/mip/gnss_4/rf_error_detection
-/mip/gnss_5/fix_info
-/mip/gnss_5/fix_info